### PR TITLE
Add onboarding, daily tips, and assistant chat flows

### DIFF
--- a/app/chat/page.js
+++ b/app/chat/page.js
@@ -1,0 +1,14 @@
+import ChatUI from '../../components/ChatUI';
+
+export const metadata = {
+  title: 'AI Chat - Infinity VR Companion',
+};
+
+export default function ChatPage() {
+  return (
+    <main className="p-4">
+      <h1 className="text-2xl font-bold mb-4">Open Chat</h1>
+      <ChatUI mode="chat" />
+    </main>
+  );
+}

--- a/app/comfort/page.js
+++ b/app/comfort/page.js
@@ -1,0 +1,14 @@
+import ChatUI from '../../components/ChatUI';
+
+export const metadata = {
+  title: 'Comfort Coach - Infinity VR Companion',
+};
+
+export default function ComfortCoachPage() {
+  return (
+    <main className="p-4">
+      <h1 className="text-2xl font-bold mb-4">Comfort Coach</h1>
+      <ChatUI mode="comfort" />
+    </main>
+  );
+}

--- a/app/game-finder/page.js
+++ b/app/game-finder/page.js
@@ -1,0 +1,14 @@
+import ChatUI from '../../components/ChatUI';
+
+export const metadata = {
+  title: 'Game Finder - Infinity VR Companion',
+};
+
+export default function GameFinderPage() {
+  return (
+    <main className="p-4">
+      <h1 className="text-2xl font-bold mb-4">Game Finder</h1>
+      <ChatUI mode="game" />
+    </main>
+  );
+}

--- a/app/onboarding/page.js
+++ b/app/onboarding/page.js
@@ -1,0 +1,9 @@
+import OnboardingContent from '../../components/OnboardingContent';
+
+export const metadata = {
+  title: 'Onboarding - Infinity VR Companion',
+};
+
+export default function OnboardingPage() {
+  return <OnboardingContent />;
+}

--- a/app/page.js
+++ b/app/page.js
@@ -1,8 +1,9 @@
+import HomeContent from '../components/HomeContent';
+
+export const metadata = {
+  title: 'Home - Infinity VR Companion',
+};
+
 export default function HomePage() {
-  return (
-    <main className="p-4">
-      <h1 className="text-xl font-bold">Infinity VR Companion</h1>
-      <p>Your VR journey begins here.</p>
-    </main>
-  );
+  return <HomeContent />;
 }

--- a/app/troubleshooter/page.js
+++ b/app/troubleshooter/page.js
@@ -1,0 +1,14 @@
+import ChatUI from '../../components/ChatUI';
+
+export const metadata = {
+  title: 'Troubleshooter - Infinity VR Companion',
+};
+
+export default function TroubleshooterPage() {
+  return (
+    <main className="p-4">
+      <h1 className="text-2xl font-bold mb-4">Troubleshooter</h1>
+      <ChatUI mode="troubleshoot" />
+    </main>
+  );
+}

--- a/components/ChatUI.jsx
+++ b/components/ChatUI.jsx
@@ -1,0 +1,104 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+const greetings = {
+  comfort:
+    "Hello! I'm your VR Comfort Coach. How can I help you feel more comfortable in VR today?",
+  troubleshoot: 'Hi, I\'m your VR Troubleshooting assistant. What issue can I help you solve?',
+  game:
+    "Hello! I'm your VR Game Finder. Tell me what you like, and I'll recommend a VR game for you.",
+  chat: "Hi there! I'm your VR companion. Ask me anything about VR!",
+};
+
+export default function ChatUI({ mode }) {
+  const [messages, setMessages] = useState([]);
+  const [conversation, setConversation] = useState([]);
+  const [input, setInput] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (mode && greetings[mode]) {
+      setMessages([{ role: 'assistant', content: greetings[mode] }]);
+    }
+  }, [mode]);
+
+  const sendMessage = async () => {
+    if (!input.trim()) return;
+
+    const userText = input.trim();
+    const userMessage = { role: 'user', content: userText };
+    setMessages((prev) => [...prev, userMessage]);
+    setConversation((prev) => [...prev, userMessage]);
+    setInput('');
+    setLoading(true);
+
+    try {
+      const response = await fetch('/api/ask', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ messages: [...conversation, userMessage], mode }),
+      });
+
+      const data = await response.json();
+      if (data.assistant) {
+        const assistantMessage = { role: 'assistant', content: data.assistant };
+        setMessages((prev) => [...prev, assistantMessage]);
+        setConversation((prev) => [...prev, assistantMessage]);
+      } else if (data.error) {
+        setMessages((prev) => [
+          ...prev,
+          { role: 'assistant', content: 'Oops, something went wrong. Please try again.' },
+        ]);
+      }
+    } catch (err) {
+      console.error('Error sending message:', err);
+      setMessages((prev) => [
+        ...prev,
+        { role: 'assistant', content: 'Network error. Please check your connection.' },
+      ]);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="chat-ui">
+      <div className="messages mb-2">
+        {messages.map((msg, idx) => (
+          <div
+            key={idx}
+            className={`mb-2 ${
+              msg.role === 'assistant' ? 'text-blue-600' : 'text-green-600 text-right'
+            }`}
+          >
+            <strong>{msg.role === 'assistant' ? 'Assistant' : 'You'}:</strong> {msg.content}
+          </div>
+        ))}
+      </div>
+      <div className="flex items-center">
+        <input
+          type="text"
+          className="flex-1 border border-gray-300 rounded px-2 py-1"
+          placeholder="Type your message..."
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          disabled={loading}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              e.preventDefault();
+              sendMessage();
+            }
+          }}
+        />
+        <button
+          onClick={sendMessage}
+          className="ml-2 px-4 py-1 bg-blue-500 text-white font-semibold rounded disabled:opacity-60"
+          disabled={loading}
+        >
+          {loading ? 'Sending...' : 'Send'}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/components/HomeContent.jsx
+++ b/components/HomeContent.jsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { useEffect } from 'react';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import tips from '../data/tips';
+import TipCard from './TipCard';
+
+export default function HomeContent() {
+  const router = useRouter();
+
+  useEffect(() => {
+    if (typeof window !== 'undefined' && !localStorage.getItem('onboarded')) {
+      router.replace('/onboarding');
+    }
+  }, [router]);
+
+  const todayIndex = new Date().getDate() % tips.length;
+  const todayTip = tips[todayIndex];
+
+  return (
+    <main className="p-4">
+      <h1 className="text-2xl font-bold mb-4">Infinity VR Companion</h1>
+      <TipCard tip={todayTip} />
+
+      <h2 className="text-xl font-semibold mt-6 mb-2">Assistant Options:</h2>
+      <ul className="space-y-2">
+        <li>
+          <Link href="/comfort" className="text-blue-600 underline">
+            Comfort Coach
+          </Link>
+        </li>
+        <li>
+          <Link href="/troubleshooter" className="text-blue-600 underline">
+            Troubleshooter
+          </Link>
+        </li>
+        <li>
+          <Link href="/game-finder" className="text-blue-600 underline">
+            Game Finder
+          </Link>
+        </li>
+        <li>
+          <Link href="/chat" className="text-blue-600 underline">
+            Open Chat
+          </Link>
+        </li>
+      </ul>
+    </main>
+  );
+}

--- a/components/OnboardingContent.jsx
+++ b/components/OnboardingContent.jsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import TipCard from './TipCard';
+import tips from '../data/tips';
+
+export default function OnboardingContent() {
+  const router = useRouter();
+
+  useEffect(() => {
+    if (typeof window !== 'undefined' && localStorage.getItem('onboarded')) {
+      router.replace('/');
+    }
+  }, [router]);
+
+  const handleContinue = () => {
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('onboarded', 'true');
+    }
+    router.replace('/');
+  };
+
+  return (
+    <main className="p-4">
+      <h1 className="text-2xl font-bold mb-4">Welcome to Infinity VR Companion</h1>
+      <p className="mb-4">Before you start, here are some quick VR tips:</p>
+      {tips.map((tip, index) => (
+        <TipCard key={index} tip={tip} />
+      ))}
+      <button
+        onClick={handleContinue}
+        className="mt-4 px-4 py-2 bg-green-600 text-white font-semibold rounded"
+      >
+        Let&apos;s Get Started
+      </button>
+    </main>
+  );
+}

--- a/components/TipCard.jsx
+++ b/components/TipCard.jsx
@@ -1,0 +1,13 @@
+export default function TipCard({ tip }) {
+  return (
+    <div className="rounded-lg shadow-md p-4 mb-4 bg-white">
+      <img
+        src={tip.image}
+        alt={tip.title}
+        className="w-full h-32 object-cover rounded"
+      />
+      <h3 className="text-lg font-bold mt-2">{tip.title}</h3>
+      <p className="text-gray-700">{tip.content}</p>
+    </div>
+  );
+}

--- a/data/tips.js
+++ b/data/tips.js
@@ -1,0 +1,22 @@
+const tips = [
+  {
+    title: "VR Safety: Take Breaks",
+    image: "/images/vr_break.svg",
+    content:
+      "Limit your VR sessions to ~20 minutes at a time, and take breaks to rest your eyes and mind. Too long in VR without a break can cause fatigue and disorientation.",
+  },
+  {
+    title: "Beginner-Friendly Game",
+    image: "/images/beat_saber.svg",
+    content:
+      "New to VR? Start with easy, comfortable games like Beat Saber or Job Simulator. These have simple controls and keep you mostly stationary to avoid motion sickness.",
+  },
+  {
+    title: "Comfort Tip: Use Settings",
+    image: "/images/comfort_settings.svg",
+    content:
+      "If you feel motion sickness, use VR comfort settings (teleport movement, snap turning, etc.). Most VR apps offer options to help you stay comfortable.",
+  },
+];
+
+export default tips;

--- a/public/images/beat_saber.svg
+++ b/public/images/beat_saber.svg
@@ -1,0 +1,11 @@
+<svg width="400" height="220" viewBox="0 0 400 220" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="grad2" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0ea5e9"/>
+      <stop offset="100%" stop-color="#2563eb"/>
+    </linearGradient>
+  </defs>
+  <rect width="400" height="220" rx="16" fill="url(#grad2)"/>
+  <text x="200" y="90" text-anchor="middle" font-size="34" fill="#e0f2fe" font-family="Arial" font-weight="bold">Beat Saber</text>
+  <text x="200" y="140" text-anchor="middle" font-size="18" fill="#dbeafe" font-family="Arial">Rhythm &amp; easy to pick up</text>
+</svg>

--- a/public/images/comfort_settings.svg
+++ b/public/images/comfort_settings.svg
@@ -1,0 +1,11 @@
+<svg width="400" height="220" viewBox="0 0 400 220" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="grad3" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#a855f7"/>
+      <stop offset="100%" stop-color="#6366f1"/>
+    </linearGradient>
+  </defs>
+  <rect width="400" height="220" rx="16" fill="url(#grad3)"/>
+  <text x="200" y="90" text-anchor="middle" font-size="30" fill="#f5f3ff" font-family="Arial" font-weight="bold">Comfort Settings</text>
+  <text x="200" y="140" text-anchor="middle" font-size="18" fill="#ede9fe" font-family="Arial">Teleport, snap turns &amp; vignettes</text>
+</svg>

--- a/public/images/vr_break.svg
+++ b/public/images/vr_break.svg
@@ -1,0 +1,11 @@
+<svg width="400" height="220" viewBox="0 0 400 220" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#4ade80"/>
+      <stop offset="100%" stop-color="#22c55e"/>
+    </linearGradient>
+  </defs>
+  <rect width="400" height="220" rx="16" fill="url(#grad)"/>
+  <text x="200" y="90" text-anchor="middle" font-size="36" fill="#ffffff" font-family="Arial" font-weight="bold">Take a Break</text>
+  <text x="200" y="140" text-anchor="middle" font-size="18" fill="#f0fdf4" font-family="Arial">Rest eyes &amp; stay hydrated</text>
+</svg>


### PR DESCRIPTION
## Summary
- add reusable tip data and card component with placeholder illustrations
- implement onboarding experience with localStorage flag plus rotating daily tip on home
- add ChatUI component and dedicated assistant pages for comfort, troubleshooting, game finding, and open chat

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c29ed05cc832bbd6085d8c439fd08)