### PR TITLE
Launch hardening: PWA icons, offline fallback, and API rate limiting

### DIFF
--- a/docs/playstore-twa.md
+++ b/docs/playstore-twa.md
@@ -1,0 +1,28 @@
+# Play Store Trusted Web Activity (TWA) Notes
+
+To publish Infinity VR Companion as a Trusted Web Activity on the Google Play Store, you need to host a Digital Asset Links file that verifies ownership of the domain and allows the Android app to handle all URLs.
+
+## Digital Asset Links configuration
+
+Host the following JSON at `https://infinityvrgaming.com/.well-known/assetlinks.json`:
+
+```json
+[
+  {
+    "relation": [
+      "delegate_permission/common.handle_all_urls"
+    ],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "<your.package.name>",
+      "sha256_cert_fingerprints": [
+        "<SHA256_CERT_FINGERPRINT>"
+      ]
+    }
+  }
+]
+```
+
+- Replace `<your.package.name>` with the Android application ID.
+- Replace `<SHA256_CERT_FINGERPRINT>` with the SHA-256 fingerprint(s) for the signing certificate(s) used by your app (add additional entries if needed).
+- Keep the JSON served from the `/.well-known/assetlinks.json` path to satisfy TWA verification.

--- a/next.config.js
+++ b/next.config.js
@@ -2,6 +2,9 @@ const withPWA = require('next-pwa')({
   dest: 'public',
   register: true,
   skipWaiting: true,
+  fallbacks: {
+    document: '/_offline',
+  },
 });
 
 module.exports = withPWA({

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "autoprefixer": "^10.4.19",
         "express": "^4.18.0",
+        "express-rate-limit": "^7.4.0",
         "next": "13.4.10",
         "next-pwa": "^5.4.2",
         "openai": "^4.0.0",
@@ -3479,6 +3480,21 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.1.tgz",
+      "integrity": "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
       }
     },
     "node_modules/fast-deep-equal": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "autoprefixer": "^10.4.19",
     "express": "^4.18.0",
+    "express-rate-limit": "^7.4.0",
     "next": "13.4.10",
     "next-pwa": "^5.4.2",
     "postcss": "^8.4.38",

--- a/pages/_offline.jsx
+++ b/pages/_offline.jsx
@@ -1,0 +1,87 @@
+import Head from 'next/head';
+import Link from 'next/link';
+
+export default function OfflinePage() {
+  const containerStyle = {
+    minHeight: '100vh',
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: '2rem',
+    backgroundColor: '#0b1021',
+    color: '#f5f6fa',
+    fontFamily: 'Inter, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
+    textAlign: 'center',
+  };
+
+  const cardStyle = {
+    maxWidth: '480px',
+    width: '100%',
+    background: 'rgba(255, 255, 255, 0.04)',
+    border: '1px solid rgba(255, 255, 255, 0.08)',
+    borderRadius: '16px',
+    padding: '24px',
+    boxShadow: '0 20px 50px rgba(0, 0, 0, 0.35)',
+    backdropFilter: 'blur(8px)',
+  };
+
+  const buttonRowStyle = {
+    display: 'flex',
+    gap: '12px',
+    justifyContent: 'center',
+    marginTop: '20px',
+    flexWrap: 'wrap',
+  };
+
+  const buttonStyle = {
+    padding: '12px 18px',
+    borderRadius: '10px',
+    border: 'none',
+    cursor: 'pointer',
+    fontWeight: 600,
+    fontSize: '15px',
+    transition: 'transform 120ms ease, box-shadow 120ms ease',
+  };
+
+  const primaryButtonStyle = {
+    ...buttonStyle,
+    background: 'linear-gradient(135deg, #7c3aed, #22d3ee)',
+    color: '#0b1021',
+    boxShadow: '0 12px 30px rgba(34, 211, 238, 0.25)',
+  };
+
+  const secondaryButtonStyle = {
+    ...buttonStyle,
+    background: 'rgba(255, 255, 255, 0.08)',
+    color: '#f5f6fa',
+    border: '1px solid rgba(255, 255, 255, 0.12)',
+  };
+
+  return (
+    <div style={containerStyle}>
+      <Head>
+        <title>You&apos;re offline</title>
+      </Head>
+      <div style={cardStyle}>
+        <h1 style={{ fontSize: '26px', marginBottom: '12px' }}>You&apos;re offline</h1>
+        <p style={{ lineHeight: 1.6, color: 'rgba(245, 246, 250, 0.85)' }}>
+          Infinity VR Companion needs an internet connection for the AI assistant.
+          When you&apos;re back online, retry to continue where you left off.
+        </p>
+        <div style={buttonRowStyle}>
+          <Link href="/" legacyBehavior>
+            <a style={primaryButtonStyle}>Go Home</a>
+          </Link>
+          <button
+            type="button"
+            onClick={() => window.location.reload()}
+            style={secondaryButtonStyle}
+          >
+            Retry
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/server.js
+++ b/server.js
@@ -1,12 +1,14 @@
 const express = require('express');
 const next = require('next');
 const OpenAI = require('openai');
+const rateLimit = require('express-rate-limit');
 
 const dev = process.env.NODE_ENV !== 'production';
 const app = next({ dev });
 const handle = app.getRequestHandler();
 
-const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+const openAiApiKey = process.env.OPENAI_API_KEY;
+const openai = openAiApiKey ? new OpenAI({ apiKey: openAiApiKey }) : null;
 
 const systemPrompts = {
   comfort:
@@ -21,30 +23,70 @@ const systemPrompts = {
 
 app.prepare().then(() => {
   const server = express();
+  server.set('trust proxy', 1);
   server.use(express.json());
 
-  server.post('/api/ask', async (req, res) => {
+  const askLimiter = rateLimit({
+    windowMs: Number(process.env.RATE_LIMIT_WINDOW_MS) || 60_000,
+    max: Number(process.env.RATE_LIMIT_MAX) || 20,
+    standardHeaders: true,
+    legacyHeaders: false,
+    handler: (req, res) => {
+      res
+        .status(429)
+        .json({ error: 'Rate limit exceeded. Please slow down.' });
+    },
+  });
+
+  server.get('/api/healthz', (req, res) => {
+    res.json({
+      ok: true,
+      hasOpenAIKey: Boolean(openAiApiKey),
+    });
+  });
+
+  server.post('/api/ask', askLimiter, async (req, res) => {
     const { messages, mode } = req.body;
 
-    if (!messages || !Array.isArray(messages)) {
-      return res.status(400).json({ error: 'Invalid request format.' });
+    if (!Array.isArray(messages)) {
+      return res.status(400).json({ error: 'Invalid messages format.' });
     }
 
-    const conversation = [];
-    if (mode && systemPrompts[mode]) {
-      conversation.push({ role: 'system', content: systemPrompts[mode] });
+    const sanitizedMessages = messages.map((message) => ({
+      role: message?.role,
+      content: message?.content,
+    }));
+
+    const hasInvalidMessage = sanitizedMessages.some(
+      (message) =>
+        !message ||
+        typeof message !== 'object' ||
+        !['user', 'assistant'].includes(message.role) ||
+        typeof message.content !== 'string',
+    );
+
+    if (hasInvalidMessage) {
+      return res.status(400).json({ error: 'Invalid messages format.' });
     }
 
-    conversation.push(...messages);
+    if (!openai || !openAiApiKey) {
+      return res.status(500).json({ error: 'Server misconfigured' });
+    }
 
     try {
-      const completion = await openai.chat.completions.create({
+      const requestPayload = {
         model: 'gpt-4o-mini',
-        messages: conversation,
-      });
+        input: sanitizedMessages,
+        max_output_tokens: 700,
+      };
 
-      const assistantReply = completion.choices[0]?.message?.content;
-      res.json({ assistant: assistantReply });
+      if (mode && systemPrompts[mode]) {
+        requestPayload.instructions = systemPrompts[mode];
+      }
+
+      const response = await openai.responses.create(requestPayload);
+
+      res.json({ assistant: response.output_text?.trim() ?? '' });
     } catch (err) {
       console.error('OpenAI API error:', err);
       res.status(500).json({ error: 'Failed to get response from AI.' });


### PR DESCRIPTION
## Summary
- add an offline fallback page and configure next-pwa to serve it when the network is unavailable
- harden the AI API with proxy trust, request validation, rate limiting, health reporting, and OpenAI Responses API usage
- document Play Store Trusted Web Activity requirements and ensure PWA assets are ready for installability

## Testing
- npm run build
- npm run start (manual) then curl checks for icons, offline fallback, healthz, /api/ask error when key missing, and rate limiting


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d879c9ce8832bad8cd9156acfb6e8)