### PR TITLE
Enhance chat UI and home mode tiles

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -199,6 +199,181 @@ main {
   box-shadow: 0 0 22px rgba(77, 232, 244, 0.25), inset 0 1px 0 rgba(255, 255, 255, 0.15);
 }
 
+.chat-shell {
+  position: relative;
+  isolation: isolate;
+  overflow: hidden;
+  background: linear-gradient(140deg, rgba(77, 232, 244, 0.08), rgba(255, 63, 164, 0.07));
+}
+
+.holo-grid {
+  background: radial-gradient(circle at 20% 20%, rgba(77, 232, 244, 0.15), transparent 28%),
+    radial-gradient(circle at 80% 0%, rgba(255, 63, 164, 0.14), transparent 26%),
+    linear-gradient(rgba(255, 255, 255, 0.04) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255, 255, 255, 0.05) 1px, transparent 1px);
+  background-size: 100% 100%, 100% 100%, 32px 32px, 32px 32px;
+  opacity: 0.55;
+}
+
+.holo-panel {
+  position: relative;
+  padding: 1rem;
+  border-radius: 1rem;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.06), rgba(255, 255, 255, 0.03));
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.15), 0 16px 44px rgba(0, 0, 0, 0.35);
+}
+
+.message-row {
+  display: flex;
+  gap: 0.8rem;
+  align-items: flex-start;
+}
+
+.message-row.user {
+  justify-content: flex-end;
+}
+
+.message-avatar {
+  height: 2.6rem;
+  width: 2.6rem;
+  display: grid;
+  place-items: center;
+  border-radius: 9999px;
+  font-size: 1.2rem;
+  background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.15), transparent 60%),
+    rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  box-shadow: 0 0 25px rgba(77, 232, 244, 0.35);
+}
+
+.message-avatar.user {
+  box-shadow: 0 0 25px rgba(255, 63, 164, 0.32);
+}
+
+.message-bubble {
+  flex: 1;
+  padding: 1rem 1rem 1.1rem;
+  border-radius: 1rem;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.07), rgba(255, 255, 255, 0.03));
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.4), inset 0 1px 0 rgba(255, 255, 255, 0.14);
+}
+
+.message-bubble.assistant {
+  border-color: rgba(77, 232, 244, 0.45);
+  box-shadow: 0 0 28px rgba(77, 232, 244, 0.25), inset 0 1px 0 rgba(255, 255, 255, 0.16);
+}
+
+.message-bubble.user {
+  border-color: rgba(255, 63, 164, 0.4);
+  box-shadow: 0 0 28px rgba(255, 63, 164, 0.2), inset 0 1px 0 rgba(255, 255, 255, 0.16);
+}
+
+.chat-input {
+  width: 100%;
+  border-radius: 9999px;
+  padding: 1rem 1.2rem;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  background: transparent;
+  color: #fff;
+  font-size: 1rem;
+  transition: border-color 150ms ease, box-shadow 150ms ease, background 150ms ease;
+}
+
+.chat-input:focus {
+  outline: none;
+  background: rgba(255, 255, 255, 0.08);
+  border-color: rgba(77, 232, 244, 0.7);
+  box-shadow: 0 0 26px rgba(77, 232, 244, 0.28), 0 0 12px rgba(255, 63, 164, 0.18);
+}
+
+.send-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  padding: 1rem 1.4rem;
+  border-radius: 9999px;
+  border: 1px solid rgba(77, 232, 244, 0.6);
+  background: radial-gradient(circle at 20% 20%, rgba(77, 232, 244, 0.22), transparent 45%),
+    radial-gradient(circle at 80% 80%, rgba(255, 63, 164, 0.22), transparent 45%),
+    linear-gradient(120deg, rgba(77, 232, 244, 0.35), rgba(255, 63, 164, 0.28));
+  color: #fff;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-weight: 700;
+  box-shadow: 0 0 18px rgba(77, 232, 244, 0.35), 0 10px 35px rgba(0, 0, 0, 0.4);
+  transition: transform 160ms ease, box-shadow 160ms ease, border-color 160ms ease;
+}
+
+.send-button:hover {
+  transform: translateY(-2px) scale(1.01);
+  border-color: rgba(255, 63, 164, 0.7);
+  box-shadow: 0 0 28px rgba(255, 63, 164, 0.35), 0 16px 40px rgba(0, 0, 0, 0.45);
+}
+
+.send-button:disabled {
+  opacity: 0.7;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.mode-card {
+  position: relative;
+  display: block;
+  padding: 1.1rem;
+  border-radius: 1rem;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.07), rgba(255, 255, 255, 0.04));
+  transition: transform 160ms ease, box-shadow 160ms ease, border-color 160ms ease;
+  overflow: hidden;
+}
+
+.mode-card::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 20% 20%, rgba(77, 232, 244, 0.15), transparent 35%),
+    radial-gradient(circle at 80% 0%, rgba(255, 63, 164, 0.16), transparent 30%);
+  opacity: 0;
+  transition: opacity 200ms ease;
+}
+
+.mode-card:hover {
+  transform: translateY(-3px);
+  border-color: rgba(77, 232, 244, 0.65);
+  box-shadow: 0 18px 46px rgba(0, 0, 0, 0.35), 0 0 24px rgba(77, 232, 244, 0.2);
+}
+
+.mode-card:hover::before {
+  opacity: 1;
+}
+
+.mode-icon {
+  height: 2.5rem;
+  width: 2.5rem;
+  display: grid;
+  place-items: center;
+  border-radius: 0.8rem;
+  background: linear-gradient(135deg, rgba(77, 232, 244, 0.25), rgba(255, 63, 164, 0.25));
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.18), 0 12px 32px rgba(0, 0, 0, 0.35);
+  font-size: 1.1rem;
+}
+
+.mode-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.25rem 0.6rem;
+  border-radius: 9999px;
+  background: rgba(77, 232, 244, 0.12);
+  border: 1px solid rgba(77, 232, 244, 0.4);
+  color: var(--vr-text);
+  font-size: 0.85rem;
+}
+
 .chat-bubble.user {
   border-color: rgba(255, 63, 164, 0.4);
   box-shadow: 0 0 18px rgba(255, 63, 164, 0.25), inset 0 1px 0 rgba(255, 255, 255, 0.1);

--- a/components/ChatUI.jsx
+++ b/components/ChatUI.jsx
@@ -69,38 +69,58 @@ export default function ChatUI({ mode }) {
   };
 
   return (
-    <div className="glass-card space-y-4">
-      <div className="messages space-y-3 max-h-[420px] overflow-y-auto pr-1">
-        {messages.map((msg, idx) => (
-          <div
-            key={idx}
-            className={`chat-bubble ${msg.role === 'assistant' ? 'assistant' : 'user'}`}
-          >
-            <strong className="block text-sm uppercase tracking-wide text-white/80">
-              {msg.role === 'assistant' ? 'Assistant' : 'You'}
-            </strong>
-            <p className="mt-1 leading-relaxed">{msg.content}</p>
+    <div className="chat-shell glass-card overflow-hidden">
+      <div className="absolute inset-0 pointer-events-none holo-grid" aria-hidden />
+      <div className="relative space-y-4">
+        <div className="holo-panel space-y-4 max-h-[420px] overflow-y-auto pr-2">
+          {messages.map((msg, idx) => (
+            <div
+              key={idx}
+              className={`message-row ${msg.role === 'assistant' ? 'assistant' : 'user'}`}
+            >
+              <div className={`message-avatar ${msg.role === 'assistant' ? 'assistant' : 'user'}`}>
+                {msg.role === 'assistant' ? '🤖' : '🧑‍🚀'}
+              </div>
+              <div
+                className={`message-bubble ${msg.role === 'assistant' ? 'assistant' : 'user'}`}
+              >
+                <div className="flex items-center gap-2 text-xs uppercase tracking-[0.16em] text-white/70">
+                  <span className="inline-block h-1.5 w-1.5 rounded-full bg-gradient-to-r from-cyan-400 to-fuchsia-500" />
+                  {msg.role === 'assistant' ? 'Assistant' : 'You'}
+                </div>
+                <p className="mt-2 leading-relaxed text-white/90">{msg.content}</p>
+              </div>
+            </div>
+          ))}
+        </div>
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+          <div className="flex-1 rounded-full border border-white/10 bg-[radial-gradient(circle_at_20%_50%,rgba(77,232,244,0.18),transparent_32%),radial-gradient(circle_at_80%_50%,rgba(255,63,164,0.16),transparent_32%),rgba(255,255,255,0.04)] shadow-[0_0_0_1px_rgba(255,255,255,0.08),0_10px_40px_rgba(0,0,0,0.35)]">
+            <input
+              type="text"
+              className="chat-input"
+              placeholder="Type your message..."
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+              disabled={loading}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  e.preventDefault();
+                  sendMessage();
+                }
+              }}
+            />
           </div>
-        ))}
-      </div>
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
-        <input
-          type="text"
-          className="input-field"
-          placeholder="Type your message..."
-          value={input}
-          onChange={(e) => setInput(e.target.value)}
-          disabled={loading}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter') {
-              e.preventDefault();
-              sendMessage();
-            }
-          }}
-        />
-        <button onClick={sendMessage} className="neon-button sm:w-auto w-full" disabled={loading}>
-          {loading ? 'Sending...' : 'Send'}
-        </button>
+          <button
+            onClick={sendMessage}
+            className="send-button sm:w-auto w-full"
+            disabled={loading}
+          >
+            <span className="text-lg">{loading ? '⏳' : '🚀'}</span>
+            <span className="font-semibold tracking-[0.12em] uppercase">
+              {loading ? 'Sending' : 'Send'}
+            </span>
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/components/HomeContent.jsx
+++ b/components/HomeContent.jsx
@@ -18,6 +18,37 @@ export default function HomeContent() {
   const todayIndex = new Date().getDate() % tips.length;
   const todayTip = tips[todayIndex];
 
+  const modes = [
+    {
+      title: 'Comfort Coach',
+      description: 'Optimize ergonomics, reduce motion sickness, and find your calm zone.',
+      href: '/comfort',
+      icon: '🧘‍♀️',
+      badge: 'Balanced',
+    },
+    {
+      title: 'Troubleshooter',
+      description: 'Diagnose glitches, guide quick fixes, and keep your headset humming.',
+      href: '/troubleshooter',
+      icon: '🛠️',
+      badge: 'Stability',
+    },
+    {
+      title: 'Game Finder',
+      description: 'Discover adventures tuned to your mood, genre, and gear.',
+      href: '/game-finder',
+      icon: '🎮',
+      badge: 'Curated',
+    },
+    {
+      title: 'Open Chat',
+      description: 'Ask anything VR—from setup hacks to lore and beyond.',
+      href: '/chat',
+      icon: '💬',
+      badge: 'Freeform',
+    },
+  ];
+
   return (
     <main className="space-y-6">
       <header className="glass-card">
@@ -31,36 +62,44 @@ export default function HomeContent() {
       <TipCard tip={todayTip} />
 
       <section className="glass-card space-y-4">
-        <div>
-          <h2 className="section-title text-xl">Assistant Options</h2>
-          <p className="subheading">Pick a mode and we&apos;ll glow the path ahead.</p>
+        <div className="flex items-center justify-between gap-3">
+          <div>
+            <h2 className="section-title text-xl">Assistant Options</h2>
+            <p className="subheading">Pick a mode and we&apos;ll glow the path ahead.</p>
+          </div>
+          <div className="mode-chip">
+            <span className="h-2 w-2 rounded-full bg-emerald-300" />
+            Live neural link
+          </div>
         </div>
-        <ul className="space-y-3">
-          <li className="list-tile">
-            <span className="font-semibold">Comfort Coach</span>
-            <Link href="/comfort" className="neon-link">
-              Open
+        <div className="grid gap-3 sm:grid-cols-2">
+          {modes.map((mode) => (
+            <Link key={mode.title} href={mode.href} className="mode-card group">
+              <div className="relative z-[1] flex items-start justify-between gap-3">
+                <div className="flex items-start gap-3">
+                  <div className="mode-icon">{mode.icon}</div>
+                  <div className="space-y-1">
+                    <h3 className="text-lg font-semibold tracking-wide group-hover:text-white">
+                      {mode.title}
+                    </h3>
+                    <p className="card-text text-sm leading-relaxed">{mode.description}</p>
+                  </div>
+                </div>
+                <div className="mode-chip">
+                  <span className="h-2 w-2 rounded-full bg-cyan-300" />
+                  {mode.badge}
+                </div>
+              </div>
+              <div className="relative z-[1] mt-3 flex items-center justify-between text-sm text-white/70">
+                <span className="flex items-center gap-2">
+                  <span className="inline-block h-1.5 w-1.5 rounded-full bg-gradient-to-r from-cyan-400 to-fuchsia-500" />
+                  Enter link
+                </span>
+                <span className="transition-transform duration-150 group-hover:translate-x-1">→</span>
+              </div>
             </Link>
-          </li>
-          <li className="list-tile">
-            <span className="font-semibold">Troubleshooter</span>
-            <Link href="/troubleshooter" className="neon-link">
-              Open
-            </Link>
-          </li>
-          <li className="list-tile">
-            <span className="font-semibold">Game Finder</span>
-            <Link href="/game-finder" className="neon-link">
-              Open
-            </Link>
-          </li>
-          <li className="list-tile">
-            <span className="font-semibold">Open Chat</span>
-            <Link href="/chat" className="neon-link">
-              Open
-            </Link>
-          </li>
-        </ul>
+          ))}
+        </div>
       </section>
     </main>
   );


### PR DESCRIPTION
## Summary
- Restyle the chat interface with holographic panels, avatars, and upgraded futuristic controls
- Replace the assistant option list with icon-driven tiles that animate on hover
- Add new global styles to support the refreshed VR-inspired surfaces and chips

## Testing
- Not run (UI changes only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693df7bd8ff8832b9a5d09068abf4b5f)