### PR TITLE
Add moderation and quota safeguards to ask endpoint

### DIFF
--- a/server.js
+++ b/server.js
@@ -10,6 +10,51 @@ const handle = app.getRequestHandler();
 const openAiApiKey = process.env.OPENAI_API_KEY;
 const openai = openAiApiKey ? new OpenAI({ apiKey: openAiApiKey }) : null;
 
+const ALLOWED_MODES = new Set(['comfort', 'troubleshoot', 'game', 'chat']);
+
+const QUOTA_WINDOW_MS = Number(process.env.QUOTA_WINDOW_MS) || 60 * 60 * 1000;
+const QUOTA_MAX_REQUESTS = Number(process.env.QUOTA_MAX_REQUESTS) || 200;
+const quotaTracker = new Map();
+
+const profanityList = ['damn', 'shit', 'fuck'];
+
+const scrubContent = (text) => {
+  if (!text) return text;
+
+  let scrubbed = text;
+
+  // Mask email addresses
+  scrubbed = scrubbed.replace(/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi, '[redacted-email]');
+
+  // Mask phone numbers (very simple patterns)
+  scrubbed = scrubbed.replace(/\b(?:\+?\d[\s-]?){7,15}\b/g, '[redacted-phone]');
+
+  // Replace profanity
+  profanityList.forEach((word) => {
+    const regex = new RegExp(`\\b${word}\\b`, 'gi');
+    scrubbed = scrubbed.replace(regex, '*'.repeat(word.length));
+  });
+
+  return scrubbed;
+};
+
+const checkQuota = (identifier) => {
+  const now = Date.now();
+  const record = quotaTracker.get(identifier);
+
+  if (!record || now - record.windowStart > QUOTA_WINDOW_MS) {
+    quotaTracker.set(identifier, { windowStart: now, count: 1 });
+    return true;
+  }
+
+  if (record.count >= QUOTA_MAX_REQUESTS) {
+    return false;
+  }
+
+  record.count += 1;
+  return true;
+};
+
 const systemPrompts = {
   comfort:
     'You are a VR Comfort Coach, an expert in virtual reality health and safety. Provide friendly, helpful advice to keep VR users comfortable and prevent motion sickness or fatigue.',
@@ -47,6 +92,17 @@ app.prepare().then(() => {
 
   server.post('/api/ask', askLimiter, async (req, res) => {
     const { messages, mode } = req.body;
+
+    if (mode && !ALLOWED_MODES.has(mode)) {
+      console.warn(`Rejected request due to invalid mode: ${mode}`);
+      return res.status(400).json({ error: 'Invalid mode specified.' });
+    }
+
+    const requesterId = `${req.ip || 'unknown-ip'}::${req.headers['x-user-id'] || 'anonymous'}`;
+    if (!checkQuota(requesterId)) {
+      console.warn(`Quota exceeded for ${requesterId}`);
+      return res.status(429).json({ error: 'Usage quota exceeded. Please try later.' });
+    }
 
     if (!Array.isArray(messages)) {
       return res.status(400).json({ error: 'Invalid messages format.' });
@@ -109,9 +165,26 @@ app.prepare().then(() => {
     }
 
     try {
+      const combinedInput = sanitizedMessages.map((message) => `${message.role}: ${message.content}`).join('\n');
+      const moderation = await openai.moderations.create({
+        model: 'omni-moderation-latest',
+        input: combinedInput,
+      });
+
+      const moderationResult = moderation.results?.[0];
+      if (moderationResult?.flagged) {
+        console.warn('Moderation flagged content', moderationResult.categories);
+        return res.status(400).json({ error: 'Content violates usage policies.', categories: moderationResult.categories });
+      }
+
+      const scrubbedMessages = sanitizedMessages.map((message) => ({
+        ...message,
+        content: scrubContent(message.content),
+      }));
+
       const requestPayload = {
         model: 'gpt-4o-mini',
-        input: sanitizedMessages,
+        input: scrubbedMessages,
         max_output_tokens: 700,
       };
 


### PR DESCRIPTION
## Summary
- enforce allowed modes and per-user/IP quotas before processing ask requests
- run user input through OpenAI moderation with audit logging and block flagged categories
- scrub profanity and PII from messages before sending them to OpenAI

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693dfce72f84832b8411ad1f4adca39a)