### PR TITLE
Add rich message previews and styling

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -199,6 +199,95 @@ main {
   box-shadow: 0 0 22px rgba(77, 232, 244, 0.25), inset 0 1px 0 rgba(255, 255, 255, 0.15);
 }
 
+.message-card {
+  margin-top: 0.75rem;
+  border-radius: 0.9rem;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  background: linear-gradient(135deg, rgba(77, 232, 244, 0.08), rgba(255, 63, 164, 0.05));
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.35), inset 0 1px 0 rgba(255, 255, 255, 0.1);
+  overflow: hidden;
+}
+
+.preview-card {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 0.85rem;
+  padding: 0.95rem;
+  color: #fff;
+  text-decoration: none;
+  transition: transform 140ms ease, box-shadow 140ms ease, border-color 140ms ease;
+}
+
+.preview-card.video {
+  grid-template-columns: minmax(0, 240px) 1fr;
+}
+
+@media (max-width: 640px) {
+  .preview-card.video {
+    grid-template-columns: 1fr;
+  }
+}
+
+.preview-card:hover,
+.preview-card:focus-visible {
+  transform: translateY(-2px);
+  outline: none;
+  box-shadow: 0 14px 38px rgba(0, 0, 0, 0.42), 0 0 20px rgba(77, 232, 244, 0.25);
+  border-color: rgba(77, 232, 244, 0.65);
+}
+
+.preview-media {
+  position: relative;
+  border-radius: 0.75rem;
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  min-height: 160px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.preview-image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.preview-placeholder {
+  width: 100%;
+  text-align: center;
+  color: rgba(255, 255, 255, 0.8);
+  letter-spacing: 0.05em;
+  font-weight: 600;
+}
+
+.preview-body {
+  display: grid;
+  gap: 0.3rem;
+}
+
+.preview-kicker {
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: rgba(255, 255, 255, 0.7);
+  font-weight: 700;
+  font-size: 0.72rem;
+}
+
+.preview-title {
+  font-size: 1.05rem;
+  font-weight: 700;
+  text-shadow: 0 0 20px rgba(77, 232, 244, 0.28);
+}
+
+.preview-description {
+  color: rgba(231, 236, 255, 0.8);
+  line-height: 1.5;
+  font-size: 0.95rem;
+}
+
 .chat-shell {
   position: relative;
   isolation: isolate;

--- a/components/ChatUI.jsx
+++ b/components/ChatUI.jsx
@@ -98,14 +98,20 @@ export default function ChatUI({ mode }) {
     () => ({
       text: (msg) => <p className="mt-2 leading-relaxed text-white/90">{msg.content}</p>,
       link: (msg) => (
-        <MessageCard message={msg} label="Link Preview">
-          <LinkPreview metadata={msg.metadata} fallbackUrl={msg.content} />
-        </MessageCard>
+        <div className="space-y-2">
+          <p className="mt-2 leading-relaxed text-white/90">{msg.content}</p>
+          <MessageCard message={msg} label="Link Preview">
+            <LinkPreview metadata={msg.metadata} fallbackUrl={msg.content} />
+          </MessageCard>
+        </div>
       ),
       video: (msg) => (
-        <MessageCard message={msg} label="Video">
-          <VideoPreview metadata={msg.metadata} fallbackUrl={msg.content} />
-        </MessageCard>
+        <div className="space-y-2">
+          <p className="mt-2 leading-relaxed text-white/90">{msg.content}</p>
+          <MessageCard message={msg} label="Video">
+            <VideoPreview metadata={msg.metadata} fallbackUrl={msg.content} />
+          </MessageCard>
+        </div>
       ),
     }),
     [],

--- a/components/ChatUI.jsx
+++ b/components/ChatUI.jsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 const greetings = {
   comfort:
@@ -19,7 +19,7 @@ export default function ChatUI({ mode }) {
 
   useEffect(() => {
     if (mode && greetings[mode]) {
-      const greetingMessage = { role: 'assistant', content: greetings[mode] };
+      const greetingMessage = { role: 'assistant', type: 'text', content: greetings[mode] };
       setMessages([greetingMessage]);
       setConversation([greetingMessage]);
     } else {
@@ -28,11 +28,20 @@ export default function ChatUI({ mode }) {
     }
   }, [mode]);
 
+  const detectMessageType = (text) => {
+    const urlRegex = /https?:\/\/[^\s]+/i;
+    const match = text.match(urlRegex);
+    if (!match) return 'text';
+    const url = match[0];
+    if (/youtube\.com|youtu\.be|vimeo\.com/i.test(url)) return 'video';
+    return 'link';
+  };
+
   const sendMessage = async () => {
     if (!input.trim()) return;
 
     const userText = input.trim();
-    const userMessage = { role: 'user', content: userText };
+    const userMessage = { role: 'user', content: userText, type: detectMessageType(userText) };
     setMessages((prev) => [...prev, userMessage]);
     const nextConversation = [...conversation, userMessage];
     setConversation(nextConversation);
@@ -47,8 +56,25 @@ export default function ChatUI({ mode }) {
       });
 
       const data = await response.json();
+
+      if (data?.enrichedUser) {
+        setMessages((prev) =>
+          prev.map((msg, idx) =>
+            idx === prev.length - 1 ? { ...msg, ...data.enrichedUser } : msg,
+          ),
+        );
+        setConversation((prev) =>
+          prev.map((msg, idx) =>
+            idx === prev.length - 1 ? { ...msg, ...data.enrichedUser } : msg,
+          ),
+        );
+      }
+
       if (data.assistant) {
-        const assistantMessage = { role: 'assistant', content: data.assistant };
+        const assistantMessage =
+          typeof data.assistant === 'string'
+            ? { role: 'assistant', content: data.assistant, type: 'text' }
+            : { role: 'assistant', type: 'text', ...data.assistant };
         setMessages((prev) => [...prev, assistantMessage]);
         setConversation((prev) => [...prev, assistantMessage]);
       } else if (data.error) {
@@ -61,11 +87,33 @@ export default function ChatUI({ mode }) {
       console.error('Error sending message:', err);
       setMessages((prev) => [
         ...prev,
-        { role: 'assistant', content: 'Network error. Please check your connection.' },
+          { role: 'assistant', content: 'Network error. Please check your connection.' },
       ]);
     } finally {
       setLoading(false);
     }
+  };
+
+  const messageRenderer = useMemo(
+    () => ({
+      text: (msg) => <p className="mt-2 leading-relaxed text-white/90">{msg.content}</p>,
+      link: (msg) => (
+        <MessageCard message={msg} label="Link Preview">
+          <LinkPreview metadata={msg.metadata} fallbackUrl={msg.content} />
+        </MessageCard>
+      ),
+      video: (msg) => (
+        <MessageCard message={msg} label="Video">
+          <VideoPreview metadata={msg.metadata} fallbackUrl={msg.content} />
+        </MessageCard>
+      ),
+    }),
+    [],
+  );
+
+  const renderMessageContent = (msg) => {
+    const renderer = messageRenderer[msg.type] || messageRenderer.text;
+    return renderer(msg);
   };
 
   return (
@@ -88,7 +136,7 @@ export default function ChatUI({ mode }) {
                   <span className="inline-block h-1.5 w-1.5 rounded-full bg-gradient-to-r from-cyan-400 to-fuchsia-500" />
                   {msg.role === 'assistant' ? 'Assistant' : 'You'}
                 </div>
-                <p className="mt-2 leading-relaxed text-white/90">{msg.content}</p>
+                {renderMessageContent(msg)}
               </div>
             </div>
           ))}
@@ -121,6 +169,59 @@ export default function ChatUI({ mode }) {
             </span>
           </button>
         </div>
+      </div>
+    </div>
+  );
+}
+
+function MessageCard({ message, children, label }) {
+  return (
+    <div className="message-card" aria-label={`${label} from ${message.role === 'assistant' ? 'assistant' : 'you'}`}>
+      {children}
+    </div>
+  );
+}
+
+function LinkPreview({ metadata, fallbackUrl }) {
+  const href = metadata?.url || fallbackUrl;
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noreferrer"
+      className="preview-card"
+    >
+      {metadata?.image && (
+        <div className="preview-media" aria-hidden>
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img src={metadata.image} alt="" className="preview-image" />
+        </div>
+      )}
+      <div className="preview-body">
+        <p className="preview-kicker">{metadata?.siteName || 'External link'}</p>
+        <p className="preview-title">{metadata?.title || href}</p>
+        <p className="preview-description">{metadata?.description || 'Tap to open this link'}</p>
+      </div>
+    </a>
+  );
+}
+
+function VideoPreview({ metadata, fallbackUrl }) {
+  const href = metadata?.url || fallbackUrl;
+  return (
+    <div className="preview-card video">
+      <a href={href} target="_blank" rel="noreferrer" className="preview-media" aria-label="Open video">
+        {metadata?.image ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img src={metadata.image} alt="Video thumbnail" className="preview-image" />
+        ) : (
+          <div className="preview-placeholder">🎬 Video link</div>
+        )}
+      </a>
+      <div className="preview-body">
+        <p className="preview-kicker">{metadata?.siteName || 'Video'}</p>
+        <p className="preview-title">{metadata?.title || 'Watch now'}</p>
+        <p className="preview-description">{metadata?.description || href}</p>
       </div>
     </div>
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "tailwindcss": "^3.4.10",
+        "undici": "^6.22.0",
         "workbox-window": "^6.5.4"
       }
     },
@@ -7112,6 +7113,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/undici": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.22.0.tgz",
+      "integrity": "sha512-hU/10obOIu62MGYjdskASR3CUAiYaFTtC9Pa6vHyf//mAipSvSQg6od2CnJswq7fvzNS3zJhxoRkgNVaHurWKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -13,11 +13,12 @@
     "express-rate-limit": "^7.4.0",
     "next": "13.4.10",
     "next-pwa": "^5.4.2",
+    "openai": "^4.0.0",
     "postcss": "^8.4.38",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "tailwindcss": "^3.4.10",
-    "workbox-window": "^6.5.4",
-    "openai": "^4.0.0"
+    "undici": "^6.22.0",
+    "workbox-window": "^6.5.4"
   }
 }

--- a/server.js
+++ b/server.js
@@ -16,6 +16,7 @@ const openai = openAiApiKey ? new OpenAI({ apiKey: openAiApiKey }) : null;
 const ALLOWED_MODES = new Set(['comfort', 'troubleshoot', 'game', 'chat']);
 
 const URL_REGEX = /https?:\/\/[^\s]+/i;
+const PREVIEW_MAX_BODY_BYTES = Number(process.env.PREVIEW_MAX_BODY_BYTES) || 512 * 1024;
 
 const QUOTA_WINDOW_MS = Number(process.env.QUOTA_WINDOW_MS) || 60 * 60 * 1000;
 const QUOTA_MAX_REQUESTS = Number(process.env.QUOTA_MAX_REQUESTS) || 200;
@@ -113,6 +114,33 @@ const parseMetaTag = (html, name) => {
   const metaRegex = new RegExp(`<meta[^>]+(?:property|name)=["']${name}["'][^>]+content=["']([^"']+)["']`, 'i');
   const match = html.match(metaRegex);
   return match?.[1];
+};
+
+const readTextWithLimit = async (response, maxBytes) => {
+  if (!response?.body) {
+    throw new Error('Missing response body');
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let received = 0;
+  let result = '';
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+
+    received += value.byteLength;
+    if (received > maxBytes) {
+      await reader.cancel();
+      throw new Error('Preview body too large');
+    }
+
+    result += decoder.decode(value, { stream: true });
+  }
+
+  result += decoder.decode();
+  return result;
 };
 
 const classifyUrlType = (url) => {
@@ -329,7 +357,21 @@ const fetchLinkPreview = async (url) => {
     if (!response || !response.ok || (response.status >= 300 && response.status < 400)) {
       throw new Error(`Status ${response?.status}`);
     }
-    const html = await response.text();
+
+    const contentType = response.headers.get('content-type') || '';
+    if (!contentType.toLowerCase().includes('text')) {
+      throw new Error('Unsupported preview content type');
+    }
+
+    const contentLengthHeader = response.headers.get('content-length');
+    if (contentLengthHeader) {
+      const contentLength = Number.parseInt(contentLengthHeader, 10);
+      if (Number.isFinite(contentLength) && contentLength > PREVIEW_MAX_BODY_BYTES) {
+        throw new Error('Preview body exceeds configured size');
+      }
+    }
+
+    const html = await readTextWithLimit(response, PREVIEW_MAX_BODY_BYTES);
 
     return {
       title:

--- a/server.js
+++ b/server.js
@@ -165,6 +165,20 @@ const isPrivateIp = (ip) => {
 
   if (net.isIP(ip) === 6) {
     const normalized = ip.toLowerCase();
+    const mappedIpv4 = normalized.match(/^::ffff:([0-9.]+)$/);
+    if (mappedIpv4) {
+      const mappedAddress = mappedIpv4[1];
+      const mappedMatch = mappedAddress.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+      if (mappedMatch) {
+        const [mappedOctet1, mappedOctet2] = mappedMatch.slice(1).map(Number);
+        if (mappedOctet1 === 10) return true;
+        if (mappedOctet1 === 127) return true;
+        if (mappedOctet1 === 192 && mappedOctet2 === 168) return true;
+        if (mappedOctet1 === 169 && mappedOctet2 === 254) return true;
+        if (mappedOctet1 === 172 && mappedOctet2 >= 16 && mappedOctet2 <= 31) return true;
+      }
+    }
+
     if (normalized.startsWith('fc') || normalized.startsWith('fd')) return true; // Unique local
     if (normalized.startsWith('fe80') || normalized.startsWith('fec0')) return true; // Link-local/site-local
   }

--- a/server.js
+++ b/server.js
@@ -247,8 +247,28 @@ const fetchLinkPreview = async (url) => {
   }
 
   try {
-    const response = await fetchWithTimeout(safeUrl, { timeoutMs: 4000 });
-    if (!response.ok) throw new Error(`Status ${response.status}`);
+    let currentUrl = safeUrl;
+    let response;
+
+    for (let i = 0; i < 2; i += 1) {
+      response = await fetchWithTimeout(currentUrl, { timeoutMs: 4000, redirect: 'manual' });
+
+      if (response.status >= 300 && response.status < 400 && response.headers.has('location')) {
+        const redirectedUrl = new URL(response.headers.get('location'), currentUrl).toString();
+        const sanitizedRedirect = await resolveSafeUrl(redirectedUrl);
+
+        if (!sanitizedRedirect) {
+          throw new Error('Redirected to unsafe URL during preview fetch');
+        }
+
+        currentUrl = sanitizedRedirect;
+        continue;
+      }
+
+      break;
+    }
+
+    if (!response || !response.ok) throw new Error(`Status ${response?.status}`);
     const html = await response.text();
 
     return {
@@ -261,7 +281,7 @@ const fetchLinkPreview = async (url) => {
         parseMetaTag(html, 'twitter:description'),
       image: parseMetaTag(html, 'og:image') || parseMetaTag(html, 'twitter:image'),
       siteName: parseMetaTag(html, 'og:site_name'),
-      url: safeUrl,
+      url: response.url || currentUrl,
     };
   } catch (err) {
     console.warn('Open Graph lookup failed:', err.message);

--- a/server.js
+++ b/server.js
@@ -12,6 +12,8 @@ const openai = openAiApiKey ? new OpenAI({ apiKey: openAiApiKey }) : null;
 
 const ALLOWED_MODES = new Set(['comfort', 'troubleshoot', 'game', 'chat']);
 
+const URL_REGEX = /https?:\/\/[^\s]+/i;
+
 const QUOTA_WINDOW_MS = Number(process.env.QUOTA_WINDOW_MS) || 60 * 60 * 1000;
 const QUOTA_MAX_REQUESTS = Number(process.env.QUOTA_MAX_REQUESTS) || 200;
 const quotaTracker = new Map();
@@ -66,6 +68,94 @@ const systemPrompts = {
     'You are a helpful AI assistant knowledgeable about VR. Engage in open conversation and answer questions about VR or any topic the user asks.',
 };
 
+const fetchWithTimeout = async (url, options = {}) => {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), options.timeoutMs || 5000);
+
+  try {
+    const response = await fetch(url, { ...options, signal: controller.signal });
+    return response;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+};
+
+const parseMetaTag = (html, name) => {
+  const metaRegex = new RegExp(`<meta[^>]+(?:property|name)=["']${name}["'][^>]+content=["']([^"']+)["']`, 'i');
+  const match = html.match(metaRegex);
+  return match?.[1];
+};
+
+const classifyUrlType = (url) => {
+  if (!url) return 'text';
+  if (/youtube\.com|youtu\.be|vimeo\.com/i.test(url)) {
+    return 'video';
+  }
+  return 'link';
+};
+
+const fetchLinkPreview = async (url) => {
+  try {
+    const noEmbedResponse = await fetchWithTimeout(
+      `https://noembed.com/embed?url=${encodeURIComponent(url)}`,
+      { timeoutMs: 4000 },
+    );
+
+    if (noEmbedResponse.ok) {
+      const data = await noEmbedResponse.json();
+      if (data?.title || data?.thumbnail_url) {
+        return {
+          title: data.title,
+          description: data.author_name,
+          image: data.thumbnail_url,
+          siteName: data.provider_name,
+          url,
+        };
+      }
+    }
+  } catch (err) {
+    console.warn('NoEmbed lookup failed:', err.message);
+  }
+
+  try {
+    const response = await fetchWithTimeout(url, { timeoutMs: 4000 });
+    if (!response.ok) throw new Error(`Status ${response.status}`);
+    const html = await response.text();
+
+    return {
+      title:
+        parseMetaTag(html, 'og:title') ||
+        parseMetaTag(html, 'twitter:title') ||
+        html.match(/<title>([^<]+)<\/title>/i)?.[1],
+      description:
+        parseMetaTag(html, 'og:description') ||
+        parseMetaTag(html, 'twitter:description'),
+      image: parseMetaTag(html, 'og:image') || parseMetaTag(html, 'twitter:image'),
+      siteName: parseMetaTag(html, 'og:site_name'),
+      url,
+    };
+  } catch (err) {
+    console.warn('Open Graph lookup failed:', err.message);
+  }
+
+  return { url };
+};
+
+const enrichMessage = async (message) => {
+  const content = message?.content || '';
+  const url = content.match(URL_REGEX)?.[0];
+
+  if (!url) {
+    return { type: 'text' };
+  }
+
+  const preview = await fetchLinkPreview(url);
+  return {
+    type: classifyUrlType(url),
+    metadata: preview,
+  };
+};
+
 app.prepare().then(() => {
   const server = express();
   server.set('trust proxy', 1);
@@ -116,6 +206,7 @@ app.prepare().then(() => {
       role: message?.role,
       content:
         typeof message?.content === 'string' ? message.content.trim() : message?.content,
+      type: message?.type || 'text',
     }));
 
     const hasInvalidMessage = sanitizedMessages.some(
@@ -193,8 +284,20 @@ app.prepare().then(() => {
       }
 
       const response = await openai.responses.create(requestPayload);
+      const assistantContent = response.output_text?.trim() ?? '';
 
-      res.json({ assistant: response.output_text?.trim() ?? '' });
+      const enrichedUserMessage = await enrichMessage(sanitizedMessages[sanitizedMessages.length - 1]);
+      const assistantEnrichment = await enrichMessage({ content: assistantContent });
+
+      res.json({
+        assistant: {
+          role: 'assistant',
+          content: assistantContent,
+          type: assistantEnrichment.type || 'text',
+          metadata: assistantEnrichment.metadata,
+        },
+        enrichedUser: enrichedUserMessage,
+      });
     } catch (err) {
       console.error('OpenAI API error:', err);
       res.status(500).json({ error: 'Failed to get response from AI.' });

--- a/server.js
+++ b/server.js
@@ -4,6 +4,7 @@ const OpenAI = require('openai');
 const rateLimit = require('express-rate-limit');
 const dns = require('dns').promises;
 const net = require('net');
+const { Agent } = require('undici');
 
 const dev = process.env.NODE_ENV !== 'production';
 const app = next({ dev });
@@ -74,8 +75,34 @@ const fetchWithTimeout = async (url, options = {}) => {
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), options.timeoutMs || 5000);
 
+  const fetchOptions = { ...options, signal: controller.signal };
+
+  if (options.lookupHost) {
+    const { hostname, address, family } = options.lookupHost;
+    fetchOptions.dispatcher =
+      options.dispatcher ||
+      new Agent({
+        connect: {
+          lookup: (host, lookupOptions, callback) => {
+            if (host === hostname) {
+              callback(null, address, family || net.isIP(address));
+              return;
+            }
+
+            dns
+              .lookup(host, { all: false, family: lookupOptions?.family || 0 })
+              .then((result) => callback(null, result.address, result.family))
+              .catch((err) => callback(err));
+          },
+          servername: hostname,
+        },
+      });
+  }
+
+  delete fetchOptions.lookupHost;
+
   try {
-    const response = await fetch(url, { ...options, signal: controller.signal });
+    const response = await fetch(url, fetchOptions);
     return response;
   } finally {
     clearTimeout(timeoutId);
@@ -147,22 +174,28 @@ const isPrivateAddress = (hostname) => {
   return false;
 };
 
-const isHostnameResolvableToPublicIp = async (hostname) => {
+const resolvePublicDns = async (hostname) => {
   try {
     const records = await dns.lookup(hostname, { all: true });
     if (!records || records.length === 0) {
-      return false;
+      return null;
     }
 
-    return records.every((record) => !isPrivateIp(record.address));
+    const publicRecords = records.filter((record) => !isPrivateIp(record.address));
+    if (publicRecords.length === 0) {
+      return null;
+    }
+
+    return publicRecords;
   } catch (err) {
     console.warn(`DNS lookup failed for ${hostname}:`, err.message);
-    return false;
+    return null;
   }
 };
 
 const resolveSafeUrl = async (rawUrl, maxRedirects = 3) => {
   let currentUrl;
+  let currentLookupHost;
   try {
     currentUrl = new URL(rawUrl);
   } catch (err) {
@@ -177,24 +210,35 @@ const resolveSafeUrl = async (rawUrl, maxRedirects = 3) => {
   for (let i = 0; i <= maxRedirects; i += 1) {
     const hostname = currentUrl.hostname.toLowerCase();
 
+    let lookupRecords;
+
     if (PREVIEW_HOST_ALLOWLIST.length > 0) {
       if (!PREVIEW_HOST_ALLOWLIST.includes(hostname)) {
+        return null;
+      }
+      lookupRecords = await resolvePublicDns(hostname);
+      if (!lookupRecords) {
         return null;
       }
     } else if (isPrivateAddress(hostname)) {
       return null;
     } else {
-      const isPublic = await isHostnameResolvableToPublicIp(hostname);
-      if (!isPublic) {
+      lookupRecords = await resolvePublicDns(hostname);
+      if (!lookupRecords) {
         return null;
       }
     }
+
+    currentLookupHost = lookupRecords?.[0]
+      ? { hostname, address: lookupRecords[0].address, family: lookupRecords[0].family }
+      : null;
 
     try {
       const headResponse = await fetchWithTimeout(currentUrl.toString(), {
         method: 'HEAD',
         redirect: 'manual',
         timeoutMs: 3000,
+        lookupHost: currentLookupHost,
       });
 
       if (headResponse.status >= 300 && headResponse.status < 400 && headResponse.headers.has('location')) {
@@ -207,7 +251,7 @@ const resolveSafeUrl = async (rawUrl, maxRedirects = 3) => {
         continue;
       }
 
-      return currentUrl.toString();
+      return { url: currentUrl.toString(), lookupHost: currentLookupHost };
     } catch (err) {
       console.warn('Preview HEAD request failed:', err.message);
       return null;
@@ -218,11 +262,13 @@ const resolveSafeUrl = async (rawUrl, maxRedirects = 3) => {
 };
 
 const fetchLinkPreview = async (url) => {
-  const safeUrl = await resolveSafeUrl(url);
+  const safeResult = await resolveSafeUrl(url);
 
-  if (!safeUrl) {
+  if (!safeResult) {
     return { url };
   }
+
+  const { url: safeUrl, lookupHost: resolvedHost } = safeResult;
 
   try {
     const noEmbedResponse = await fetchWithTimeout(
@@ -248,11 +294,15 @@ const fetchLinkPreview = async (url) => {
 
   try {
     let currentUrl = safeUrl;
+    let currentLookupHost = resolvedHost;
     let response;
     const previewFetchOptions = { timeoutMs: 4000, redirect: 'manual' };
 
     for (let i = 0; i < 2; i += 1) {
-      response = await fetchWithTimeout(currentUrl, previewFetchOptions);
+      response = await fetchWithTimeout(currentUrl, {
+        ...previewFetchOptions,
+        lookupHost: currentLookupHost,
+      });
 
       if (response.status >= 300 && response.status < 400 && response.headers.has('location')) {
         const redirectedUrl = new URL(response.headers.get('location'), currentUrl).toString();
@@ -262,7 +312,8 @@ const fetchLinkPreview = async (url) => {
           throw new Error('Redirected to unsafe URL during preview fetch');
         }
 
-        currentUrl = sanitizedRedirect;
+        currentUrl = sanitizedRedirect.url;
+        currentLookupHost = sanitizedRedirect.lookupHost;
         continue;
       }
 
@@ -427,7 +478,7 @@ app.prepare().then(() => {
       }
 
       const scrubbedMessages = sanitizedMessages.map((message) => ({
-        ...message,
+        role: message.role,
         content: scrubContent(message.content),
       }));
 

--- a/server.js
+++ b/server.js
@@ -94,7 +94,63 @@ const classifyUrlType = (url) => {
   return 'link';
 };
 
+const PREVIEW_HOST_ALLOWLIST = (process.env.PREVIEW_HOST_ALLOWLIST || '')
+  .split(',')
+  .map((host) => host.trim().toLowerCase())
+  .filter(Boolean);
+
+const isPrivateAddress = (hostname) => {
+  if (!hostname) return true;
+
+  const normalized = hostname.toLowerCase();
+  if (normalized === 'localhost' || normalized === '127.0.0.1' || normalized === '::1') {
+    return true;
+  }
+
+  // Match common private network ranges without DNS resolution
+  const ipv4Match = normalized.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+  if (ipv4Match) {
+    const [octet1, octet2] = ipv4Match.slice(1).map(Number);
+    if (octet1 === 10) return true;
+    if (octet1 === 127) return true;
+    if (octet1 === 192 && octet2 === 168) return true;
+    if (octet1 === 169 && octet2 === 254) return true;
+    if (octet1 === 172 && octet2 >= 16 && octet2 <= 31) return true;
+  }
+
+  // Block obvious internal hostnames
+  if (/[.]local$|[.]internal$|[.]localhost$/.test(normalized)) {
+    return true;
+  }
+
+  return false;
+};
+
+const isPreviewUrlAllowed = (rawUrl) => {
+  try {
+    const parsed = new URL(rawUrl);
+    if (!['http:', 'https:'].includes(parsed.protocol)) {
+      return false;
+    }
+
+    const hostname = parsed.hostname.toLowerCase();
+
+    if (PREVIEW_HOST_ALLOWLIST.length > 0) {
+      return PREVIEW_HOST_ALLOWLIST.includes(hostname);
+    }
+
+    return !isPrivateAddress(hostname);
+  } catch (err) {
+    console.warn('Rejected preview URL:', err.message);
+    return false;
+  }
+};
+
 const fetchLinkPreview = async (url) => {
+  if (!isPreviewUrlAllowed(url)) {
+    return { url };
+  }
+
   try {
     const noEmbedResponse = await fetchWithTimeout(
       `https://noembed.com/embed?url=${encodeURIComponent(url)}`,

--- a/server.js
+++ b/server.js
@@ -2,6 +2,8 @@ const express = require('express');
 const next = require('next');
 const OpenAI = require('openai');
 const rateLimit = require('express-rate-limit');
+const dns = require('dns').promises;
+const net = require('net');
 
 const dev = process.env.NODE_ENV !== 'production';
 const app = next({ dev });
@@ -99,16 +101,20 @@ const PREVIEW_HOST_ALLOWLIST = (process.env.PREVIEW_HOST_ALLOWLIST || '')
   .map((host) => host.trim().toLowerCase())
   .filter(Boolean);
 
-const isPrivateAddress = (hostname) => {
-  if (!hostname) return true;
+const isPrivateIp = (ip) => {
+  if (!ip) return true;
 
-  const normalized = hostname.toLowerCase();
-  if (normalized === 'localhost' || normalized === '127.0.0.1' || normalized === '::1') {
+  if (ip === '127.0.0.1' || ip === '::1') {
     return true;
   }
 
-  // Match common private network ranges without DNS resolution
-  const ipv4Match = normalized.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+  if (net.isIP(ip) === 6) {
+    const normalized = ip.toLowerCase();
+    if (normalized.startsWith('fc') || normalized.startsWith('fd')) return true; // Unique local
+    if (normalized.startsWith('fe80') || normalized.startsWith('fec0')) return true; // Link-local/site-local
+  }
+
+  const ipv4Match = ip.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
   if (ipv4Match) {
     const [octet1, octet2] = ipv4Match.slice(1).map(Number);
     if (octet1 === 10) return true;
@@ -116,6 +122,21 @@ const isPrivateAddress = (hostname) => {
     if (octet1 === 192 && octet2 === 168) return true;
     if (octet1 === 169 && octet2 === 254) return true;
     if (octet1 === 172 && octet2 >= 16 && octet2 <= 31) return true;
+  }
+
+  return false;
+};
+
+const isPrivateAddress = (hostname) => {
+  if (!hostname) return true;
+
+  const normalized = hostname.toLowerCase();
+  if (net.isIP(normalized)) {
+    return isPrivateIp(normalized);
+  }
+
+  if (normalized === 'localhost' || normalized === '127.0.0.1' || normalized === '::1') {
+    return true;
   }
 
   // Block obvious internal hostnames
@@ -126,34 +147,86 @@ const isPrivateAddress = (hostname) => {
   return false;
 };
 
-const isPreviewUrlAllowed = (rawUrl) => {
+const isHostnameResolvableToPublicIp = async (hostname) => {
   try {
-    const parsed = new URL(rawUrl);
-    if (!['http:', 'https:'].includes(parsed.protocol)) {
+    const records = await dns.lookup(hostname, { all: true });
+    if (!records || records.length === 0) {
       return false;
     }
 
-    const hostname = parsed.hostname.toLowerCase();
-
-    if (PREVIEW_HOST_ALLOWLIST.length > 0) {
-      return PREVIEW_HOST_ALLOWLIST.includes(hostname);
-    }
-
-    return !isPrivateAddress(hostname);
+    return records.every((record) => !isPrivateIp(record.address));
   } catch (err) {
-    console.warn('Rejected preview URL:', err.message);
+    console.warn(`DNS lookup failed for ${hostname}:`, err.message);
     return false;
   }
 };
 
+const resolveSafeUrl = async (rawUrl, maxRedirects = 3) => {
+  let currentUrl;
+  try {
+    currentUrl = new URL(rawUrl);
+  } catch (err) {
+    console.warn('Rejected preview URL:', err.message);
+    return null;
+  }
+
+  if (!['http:', 'https:'].includes(currentUrl.protocol)) {
+    return null;
+  }
+
+  for (let i = 0; i <= maxRedirects; i += 1) {
+    const hostname = currentUrl.hostname.toLowerCase();
+
+    if (PREVIEW_HOST_ALLOWLIST.length > 0) {
+      if (!PREVIEW_HOST_ALLOWLIST.includes(hostname)) {
+        return null;
+      }
+    } else if (isPrivateAddress(hostname)) {
+      return null;
+    } else {
+      const isPublic = await isHostnameResolvableToPublicIp(hostname);
+      if (!isPublic) {
+        return null;
+      }
+    }
+
+    try {
+      const headResponse = await fetchWithTimeout(currentUrl.toString(), {
+        method: 'HEAD',
+        redirect: 'manual',
+        timeoutMs: 3000,
+      });
+
+      if (headResponse.status >= 300 && headResponse.status < 400 && headResponse.headers.has('location')) {
+        const location = headResponse.headers.get('location');
+        const nextUrl = new URL(location, currentUrl);
+        if (nextUrl.protocol !== 'http:' && nextUrl.protocol !== 'https:') {
+          return null;
+        }
+        currentUrl = nextUrl;
+        continue;
+      }
+
+      return currentUrl.toString();
+    } catch (err) {
+      console.warn('Preview HEAD request failed:', err.message);
+      return null;
+    }
+  }
+
+  return null;
+};
+
 const fetchLinkPreview = async (url) => {
-  if (!isPreviewUrlAllowed(url)) {
+  const safeUrl = await resolveSafeUrl(url);
+
+  if (!safeUrl) {
     return { url };
   }
 
   try {
     const noEmbedResponse = await fetchWithTimeout(
-      `https://noembed.com/embed?url=${encodeURIComponent(url)}`,
+      `https://noembed.com/embed?url=${encodeURIComponent(safeUrl)}`,
       { timeoutMs: 4000 },
     );
 
@@ -165,7 +238,7 @@ const fetchLinkPreview = async (url) => {
           description: data.author_name,
           image: data.thumbnail_url,
           siteName: data.provider_name,
-          url,
+          url: safeUrl,
         };
       }
     }
@@ -174,7 +247,7 @@ const fetchLinkPreview = async (url) => {
   }
 
   try {
-    const response = await fetchWithTimeout(url, { timeoutMs: 4000 });
+    const response = await fetchWithTimeout(safeUrl, { timeoutMs: 4000 });
     if (!response.ok) throw new Error(`Status ${response.status}`);
     const html = await response.text();
 
@@ -188,7 +261,7 @@ const fetchLinkPreview = async (url) => {
         parseMetaTag(html, 'twitter:description'),
       image: parseMetaTag(html, 'og:image') || parseMetaTag(html, 'twitter:image'),
       siteName: parseMetaTag(html, 'og:site_name'),
-      url,
+      url: safeUrl,
     };
   } catch (err) {
     console.warn('Open Graph lookup failed:', err.message);

--- a/server.js
+++ b/server.js
@@ -249,9 +249,10 @@ const fetchLinkPreview = async (url) => {
   try {
     let currentUrl = safeUrl;
     let response;
+    const previewFetchOptions = { timeoutMs: 4000, redirect: 'manual' };
 
     for (let i = 0; i < 2; i += 1) {
-      response = await fetchWithTimeout(currentUrl, { timeoutMs: 4000, redirect: 'manual' });
+      response = await fetchWithTimeout(currentUrl, previewFetchOptions);
 
       if (response.status >= 300 && response.status < 400 && response.headers.has('location')) {
         const redirectedUrl = new URL(response.headers.get('location'), currentUrl).toString();
@@ -265,10 +266,18 @@ const fetchLinkPreview = async (url) => {
         continue;
       }
 
+      // Even though we explicitly request manual redirects, double check the response
+      // did not already follow a redirect to an unsafe target.
+      if (response.redirected) {
+        throw new Error('Preview fetch unexpectedly followed a redirect');
+      }
+
       break;
     }
 
-    if (!response || !response.ok) throw new Error(`Status ${response?.status}`);
+    if (!response || !response.ok || (response.status >= 300 && response.status < 400)) {
+      throw new Error(`Status ${response?.status}`);
+    }
     const html = await response.text();
 
     return {


### PR DESCRIPTION
## Summary
- extend chat UI to support text, link, and video message types with preview cards
- fetch lightweight oEmbed/Open Graph data on the server to enrich URLs
- style preview cards to match the neon/glass theme with accessible, responsive layout

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693dfef7c000832ba38f0e9cdce38c30)