### PR TITLE
Add home content feeds with chat presets and loading states

### DIFF
--- a/app/chat/page.js
+++ b/app/chat/page.js
@@ -4,14 +4,16 @@ export const metadata = {
   title: 'AI Chat - Infinity VR Companion',
 };
 
-export default function ChatPage() {
+export default function ChatPage({ searchParams }) {
+  const presetPrompt = searchParams?.prompt ? String(searchParams.prompt) : '';
+
   return (
     <main className="space-y-5">
       <header className="glass-card">
         <h1 className="section-title text-2xl">Open Chat</h1>
         <p className="subheading">Freeform VR guidance with a luminous companion voice.</p>
       </header>
-      <ChatUI mode="chat" />
+      <ChatUI mode="chat" presetPrompt={presetPrompt} />
     </main>
   );
 }

--- a/components/ChatUI.jsx
+++ b/components/ChatUI.jsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
 const greetings = {
   comfort:
@@ -11,22 +11,27 @@ const greetings = {
   chat: "Hi there! I'm your VR companion. Ask me anything about VR!",
 };
 
-export default function ChatUI({ mode }) {
+export default function ChatUI({ mode, presetPrompt }) {
   const [messages, setMessages] = useState([]);
   const [conversation, setConversation] = useState([]);
   const [input, setInput] = useState('');
   const [loading, setLoading] = useState(false);
+  const presetHandledRef = useRef('');
 
   useEffect(() => {
     if (mode && greetings[mode]) {
       const greetingMessage = { role: 'assistant', type: 'text', content: greetings[mode] };
       setMessages([greetingMessage]);
       setConversation([greetingMessage]);
+      setInput(presetPrompt || '');
+      presetHandledRef.current = '';
     } else {
       setMessages([]);
       setConversation([]);
+      setInput('');
+      presetHandledRef.current = '';
     }
-  }, [mode]);
+  }, [mode, presetPrompt]);
 
   const detectMessageType = (text) => {
     const urlRegex = /https?:\/\/[^\s]+/i;
@@ -37,15 +42,18 @@ export default function ChatUI({ mode }) {
     return 'link';
   };
 
-  const sendMessage = async () => {
-    if (!input.trim()) return;
+  const sendMessage = async (payloadText, baseConversation = conversation) => {
+    const messageText = typeof payloadText === 'string' ? payloadText : input;
+    if (!messageText?.trim()) return;
 
-    const userText = input.trim();
+    const userText = messageText.trim();
     const userMessage = { role: 'user', content: userText, type: detectMessageType(userText) };
     setMessages((prev) => [...prev, userMessage]);
-    const nextConversation = [...conversation, userMessage];
+    const nextConversation = [...baseConversation, userMessage];
     setConversation(nextConversation);
-    setInput('');
+    if (typeof payloadText !== 'string') {
+      setInput('');
+    }
     setLoading(true);
 
     try {
@@ -93,6 +101,13 @@ export default function ChatUI({ mode }) {
       setLoading(false);
     }
   };
+
+  useEffect(() => {
+    if (!presetPrompt || presetHandledRef.current === presetPrompt) return;
+    if (!conversation.length && mode) return;
+    presetHandledRef.current = presetPrompt;
+    sendMessage(presetPrompt, conversation);
+  }, [conversation, mode, presetPrompt]);
 
   const messageRenderer = useMemo(
     () => ({

--- a/components/HomeContent.jsx
+++ b/components/HomeContent.jsx
@@ -1,19 +1,41 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import tips from '../data/tips';
+import homeContent from '../data/homeContent';
 import TipCard from './TipCard';
 
 export default function HomeContent() {
   const router = useRouter();
+  const [content, setContent] = useState({ reels: [], guides: [], games: [] });
+  const [loadingContent, setLoadingContent] = useState(true);
 
   useEffect(() => {
     if (typeof window !== 'undefined' && !localStorage.getItem('onboarded')) {
       router.replace('/onboarding');
     }
   }, [router]);
+
+  useEffect(() => {
+    let mounted = true;
+    setLoadingContent(true);
+
+    const timer = setTimeout(() => {
+      if (!mounted) return;
+      const reels = homeContent?.reels ?? [];
+      const guides = homeContent?.guides ?? [];
+      const games = homeContent?.games ?? [];
+      setContent({ reels, guides, games });
+      setLoadingContent(false);
+    }, 200);
+
+    return () => {
+      mounted = false;
+      clearTimeout(timer);
+    };
+  }, []);
 
   const todayIndex = new Date().getDate() % tips.length;
   const todayTip = tips[todayIndex];
@@ -48,6 +70,39 @@ export default function HomeContent() {
       badge: 'Freeform',
     },
   ];
+
+  const sectionConfigs = useMemo(
+    () => [
+      {
+        id: 'reels',
+        title: 'Trending Reels',
+        description: 'Quick-hit highlights and walkthroughs making waves right now.',
+        emptyCopy: 'When reels are offline, you can still ping the assistant about your latest clips.',
+        items: content.reels,
+        badgeLabel: 'Reel',
+        ctaLabel: 'Ask about this reel',
+      },
+      {
+        id: 'guides',
+        title: 'Featured Guides',
+        description: 'Curated how-tos that pair perfectly with on-demand coaching.',
+        emptyCopy: 'Guides will reload soon—ask the assistant to tailor a setup checklist meanwhile.',
+        items: content.guides,
+        badgeLabel: 'Guide',
+        ctaLabel: 'Tailor this guide',
+      },
+      {
+        id: 'games',
+        title: 'Hot Game Picks',
+        description: 'Fresh titles the companion can brief you on before you dive in.',
+        emptyCopy: 'Game picks are warming up—ask the assistant for a recommendation while you wait.',
+        items: content.games,
+        badgeLabel: 'Game',
+        ctaLabel: 'Plan my session',
+      },
+    ],
+    [content],
+  );
 
   return (
     <main className="space-y-6">
@@ -101,6 +156,150 @@ export default function HomeContent() {
           ))}
         </div>
       </section>
+
+      {sectionConfigs.map((section) => (
+        <ContentSection
+          key={section.id}
+          {...section}
+          loading={loadingContent}
+          chatLabel={section.ctaLabel}
+        />
+      ))}
     </main>
+  );
+}
+
+function ContentSection({ title, description, items, badgeLabel, chatLabel, loading, emptyCopy }) {
+  return (
+    <section className="glass-card space-y-4">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div className="space-y-1">
+          <h2 className="section-title text-xl">{title}</h2>
+          <p className="subheading text-sm sm:text-base">{description}</p>
+        </div>
+        <div className="mode-chip">
+          <span className="h-2 w-2 rounded-full bg-fuchsia-300" />
+          Powered feed preview
+        </div>
+      </div>
+
+      {loading ? (
+        <LoadingGrid />
+      ) : items.length ? (
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {items.map((item) => (
+            <ContentCard key={item.id} item={item} badgeLabel={badgeLabel} chatLabel={chatLabel} />
+          ))}
+        </div>
+      ) : (
+        <EmptyState message={emptyCopy} />
+      )}
+    </section>
+  );
+}
+
+function ContentCard({ item, badgeLabel, chatLabel }) {
+  const chatHref = `/chat?prompt=${encodeURIComponent(item.prompt)}`;
+
+  return (
+    <article className="relative overflow-hidden rounded-xl border border-white/10 bg-white/5 p-3 shadow-[0_14px_35px_rgba(0,0,0,0.35)]">
+      <div className="absolute inset-0 bg-gradient-to-br from-white/10 via-transparent to-white/5" aria-hidden />
+      <div className="relative space-y-3">
+        <div className="flex items-center gap-2 text-xs uppercase tracking-[0.16em] text-white/70">
+          <span className="inline-flex items-center gap-2 rounded-full bg-white/10 px-2 py-1 text-[11px] font-semibold">
+            <span className="inline-block h-2 w-2 rounded-full bg-cyan-300" />
+            {badgeLabel}
+          </span>
+          {item.duration && <span className="text-white/60">{item.duration}</span>}
+        </div>
+
+        <div className="card-image">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={item.thumbnail}
+            alt={item.title}
+            className="h-44 w-full object-cover"
+            loading="lazy"
+          />
+        </div>
+
+        <div className="space-y-2">
+          <h3 className="text-lg font-semibold tracking-wide">{item.title}</h3>
+          <p className="card-text text-sm leading-relaxed">{item.description}</p>
+          <div className="flex flex-wrap gap-2">
+            {item.tags?.map((tag) => (
+              <span
+                key={tag}
+                className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs font-semibold uppercase tracking-[0.14em] text-white/80"
+              >
+                {tag}
+              </span>
+            ))}
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <Link
+            href={item.link}
+            className="inline-flex items-center gap-2 text-sm font-semibold text-cyan-200 hover:text-white"
+            target="_blank"
+            rel="noreferrer"
+          >
+            View source
+            <span aria-hidden>↗</span>
+          </Link>
+          <Link
+            href={chatHref}
+            className="inline-flex items-center justify-center gap-2 rounded-full border border-cyan-300/50 bg-gradient-to-r from-cyan-400/20 to-fuchsia-500/20 px-3 py-2 text-sm font-semibold uppercase tracking-[0.14em] text-white shadow-[0_0_18px_rgba(77,232,244,0.28)] transition hover:border-fuchsia-300/60"
+          >
+            {chatLabel}
+            <span aria-hidden>💬</span>
+          </Link>
+        </div>
+      </div>
+    </article>
+  );
+}
+
+function LoadingGrid() {
+  return (
+    <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+      {Array.from({ length: 3 }).map((_, idx) => (
+        <div
+          key={idx}
+          className="animate-pulse space-y-3 rounded-xl border border-white/10 bg-white/5 p-3 shadow-[0_14px_35px_rgba(0,0,0,0.25)]"
+        >
+          <div className="flex items-center gap-2">
+            <span className="h-5 w-20 rounded-full bg-white/10" />
+            <span className="h-4 w-10 rounded-full bg-white/10" />
+          </div>
+          <div className="h-44 w-full rounded-lg bg-white/10" />
+          <div className="h-5 w-3/4 rounded-full bg-white/10" />
+          <div className="h-4 w-full rounded-full bg-white/10" />
+          <div className="flex gap-2">
+            <span className="h-6 w-16 rounded-full bg-white/10" />
+            <span className="h-6 w-14 rounded-full bg-white/10" />
+          </div>
+          <div className="flex gap-2">
+            <span className="h-10 w-24 rounded-full bg-white/10" />
+            <span className="h-10 w-28 rounded-full bg-white/10" />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function EmptyState({ message }) {
+  return (
+    <div className="flex items-center justify-between gap-3 rounded-xl border border-dashed border-white/20 bg-white/5 p-4">
+      <div className="space-y-1">
+        <p className="text-sm font-semibold uppercase tracking-[0.14em] text-white/80">Feed offline</p>
+        <p className="card-text text-sm leading-relaxed">{message}</p>
+      </div>
+      <span className="text-2xl" role="img" aria-label="sleeping robot">
+        🤖
+      </span>
+    </div>
   );
 }

--- a/data/homeContent.js
+++ b/data/homeContent.js
@@ -1,0 +1,109 @@
+const homeContent = {
+  reels: [
+    {
+      id: 'reel-quantum',
+      title: 'Quantum Drift: Smooth Locomotion Drills',
+      description: 'Mini-reel on easing into smooth locomotion with horizon locks and snap turns.',
+      thumbnail:
+        'https://images.unsplash.com/photo-1604079628040-94301bb21b91?auto=format&fit=crop&w=800&q=80',
+      duration: '2:14',
+      tags: ['Comfort', 'Movement'],
+      link: 'https://example.com/reels/quantum-drift',
+      prompt:
+        'Can you walk me through the Quantum Drift reel tips for reducing motion sickness and practicing movement drills?',
+    },
+    {
+      id: 'reel-bossfight',
+      title: 'Bossfight Highlights: Neon Titan',
+      description: 'Cinematic recap with positioning cues and quick ability counters.',
+      thumbnail:
+        'https://images.unsplash.com/photo-1511512578047-dfb367046420?auto=format&fit=crop&w=800&q=80',
+      duration: '1:48',
+      tags: ['Action', 'Strategy'],
+      link: 'https://example.com/reels/neon-titan',
+      prompt:
+        'I just watched the Neon Titan reel—help me plan a clean takedown and gear choices based on what was shown.',
+    },
+    {
+      id: 'reel-builder',
+      title: 'Base Builder Speedrun',
+      description: 'Rapid base build with resource routing and defensive overlaps.',
+      thumbnail:
+        'https://images.unsplash.com/photo-1618005182384-a83a8bd57fbe?auto=format&fit=crop&w=800&q=80',
+      duration: '3:05',
+      tags: ['Creative', 'Guide'],
+      link: 'https://example.com/reels/base-builder',
+      prompt:
+        'Use the Base Builder speedrun reel to suggest a step-by-step plan for my next creative session.',
+    },
+  ],
+  guides: [
+    {
+      id: 'guide-setup',
+      title: 'Zero-Drift Setup Checklist',
+      description: 'Room prep, guardian tuning, and cable routing for latency-friendly play.',
+      thumbnail:
+        'https://images.unsplash.com/photo-1554244933-d876deb6b2ff?auto=format&fit=crop&w=800&q=80',
+      tags: ['Setup', 'Latency'],
+      link: 'https://example.com/guides/zero-drift',
+      prompt:
+        'Can you personalize the Zero-Drift Setup checklist for my play space and headset?',
+    },
+    {
+      id: 'guide-audio',
+      title: 'Spatial Audio Tuning',
+      description: 'EQ curves, ear pad tweaks, and game-specific presets for clarity.',
+      thumbnail:
+        'https://images.unsplash.com/photo-1512310604669-443f26c35f52?auto=format&fit=crop&w=800&q=80',
+      tags: ['Audio', 'Immersion'],
+      link: 'https://example.com/guides/spatial-audio',
+      prompt: 'Apply the Spatial Audio Tuning guide to my headset and recommend presets for RPGs.',
+    },
+    {
+      id: 'guide-care',
+      title: 'Lens Care & Clarity',
+      description: 'Fast cleaning routine, humidity checks, and safe anti-fog options.',
+      thumbnail:
+        'https://images.unsplash.com/photo-1523395243481-163f8f6155d8?auto=format&fit=crop&w=800&q=80',
+      tags: ['Maintenance'],
+      link: 'https://example.com/guides/lens-care',
+      prompt: 'Use the Lens Care & Clarity guide to recommend a weekly maintenance routine for me.',
+    },
+  ],
+  games: [
+    {
+      id: 'game-neon-fleet',
+      title: 'Neon Fleet Tactics',
+      description: 'Tactical starfighter roguelite with co-op sorties.',
+      thumbnail:
+        'https://images.unsplash.com/photo-1505740420928-5e560c06d30e?auto=format&fit=crop&w=800&q=80',
+      tags: ['Co-op', 'Roguelite'],
+      link: 'https://example.com/games/neon-fleet',
+      prompt:
+        'Based on the Neon Fleet Tactics listing, what builds or ships should I prioritize for co-op runs?',
+    },
+    {
+      id: 'game-echo-depths',
+      title: 'Echo Depths',
+      description: 'Atmospheric puzzle adventure with reactive soundtrack.',
+      thumbnail:
+        'https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=800&q=80',
+      tags: ['Puzzle', 'Immersion'],
+      link: 'https://example.com/games/echo-depths',
+      prompt:
+        'How can I get the most out of Echo Depths if I love environmental puzzles and music-driven cues?',
+    },
+    {
+      id: 'game-arena',
+      title: 'Arena Pulse',
+      description: 'High-speed PvP arena with dash grapples and shield breaks.',
+      thumbnail:
+        'https://images.unsplash.com/photo-1493711662062-fa541adb3fc8?auto=format&fit=crop&w=800&q=80',
+      tags: ['Multiplayer', 'Action'],
+      link: 'https://example.com/games/arena-pulse',
+      prompt: 'Give me an Arena Pulse warmup and loadout plan inspired by the listing details.',
+    },
+  ],
+};
+
+export default homeContent;


### PR DESCRIPTION
## Summary
- add static home content dataset for trending reels, featured guides, and hot game picks
- render new card grids on the home page with thumbnails, chat CTAs, and graceful loading/empty states
- allow chat page to accept preset prompts and auto-seed conversations for media-driven handoffs

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693e9d1dfc68832bbfe80b6648757869)