### PR TITLE
Add Redis-backed quota store with fallback logging

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "express": "^4.18.0",
         "express-rate-limit": "^7.4.0",
         "helmet": "^8.1.0",
+        "ioredis": "^5.8.2",
         "next": "13.4.10",
         "next-pwa": "^5.4.2",
         "openai": "^4.0.0",
@@ -1538,6 +1539,12 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@ioredis/commands": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.4.0.tgz",
+      "integrity": "sha512-aFT2yemJJo+TZCmieA7qnYGQooOS7QfNmYrzGtsYd3g9j5iDP8AimYYAesf79ohjbLG12XxC4nG5DyEnC88AsQ==",
+      "license": "MIT"
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -2786,6 +2793,15 @@
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
     },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -3078,6 +3094,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/depd": {
@@ -4162,6 +4187,53 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/ioredis": {
+      "version": "5.8.2",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.8.2.tgz",
+      "integrity": "sha512-C6uC+kleiIMmjViJINWk80sOQw5lEzse1ZmvD+S/s8p8CWapftSaC+kocGTx6xrbrJ4WmYQGC08ffHLr6ToR6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@ioredis/commands": "1.4.0",
+        "cluster-key-slot": "^1.1.0",
+        "debug": "^4.3.4",
+        "denque": "^2.1.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.isarguments": "^3.1.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0",
+        "standard-as-callback": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ioredis"
+      }
+    },
+    "node_modules/ioredis/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ioredis/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -4812,6 +4884,18 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
       "license": "MIT"
     },
     "node_modules/lodash.sortby": {
@@ -5836,6 +5920,27 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "license": "MIT",
+      "dependencies": {
+        "redis-errors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -6501,6 +6606,12 @@
       "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
       "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
       "deprecated": "Please use @jridgewell/sourcemap-codec instead",
+      "license": "MIT"
+    },
+    "node_modules/standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
       "license": "MIT"
     },
     "node_modules/statuses": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "express": "^4.18.0",
     "express-rate-limit": "^7.4.0",
     "helmet": "^8.1.0",
+    "ioredis": "^5.8.2",
     "next": "13.4.10",
     "next-pwa": "^5.4.2",
     "openai": "^4.0.0",

--- a/server.js
+++ b/server.js
@@ -6,6 +6,7 @@ const helmet = require('helmet');
 const dns = require('dns').promises;
 const net = require('net');
 const { Agent } = require('undici');
+const Redis = require('ioredis');
 
 const dev = process.env.NODE_ENV !== 'production';
 const app = next({ dev });
@@ -29,7 +30,13 @@ const PREVIEW_MAX_BODY_BYTES = Number(process.env.PREVIEW_MAX_BODY_BYTES) || 512
 
 const QUOTA_WINDOW_MS = Number(process.env.QUOTA_WINDOW_MS) || 60 * 60 * 1000;
 const QUOTA_MAX_REQUESTS = Number(process.env.QUOTA_MAX_REQUESTS) || 200;
-const quotaTracker = new Map();
+
+const quotaRedisUrl = process.env.QUOTA_REDIS_URL;
+const quotaRedis = quotaRedisUrl
+  ? new Redis(quotaRedisUrl, { enableOfflineQueue: false })
+  : null;
+const fallbackQuotaTracker = new Map();
+let quotaStoreFailureCount = 0;
 
 const profanityList = ['damn', 'shit', 'fuck'];
 
@@ -53,12 +60,24 @@ const scrubContent = (text) => {
   return scrubbed;
 };
 
-const checkQuota = (identifier) => {
+const logQuotaStoreFailure = (err) => {
+  quotaStoreFailureCount += 1;
+  console.warn('Quota store unavailable; using fallback tracker', {
+    error: err?.message || err,
+    failures: quotaStoreFailureCount,
+  });
+};
+
+if (quotaRedis) {
+  quotaRedis.on('error', (err) => logQuotaStoreFailure(err));
+}
+
+const checkQuotaFallback = (identifier) => {
   const now = Date.now();
-  const record = quotaTracker.get(identifier);
+  const record = fallbackQuotaTracker.get(identifier);
 
   if (!record || now - record.windowStart > QUOTA_WINDOW_MS) {
-    quotaTracker.set(identifier, { windowStart: now, count: 1 });
+    fallbackQuotaTracker.set(identifier, { windowStart: now, count: 1 });
     return true;
   }
 
@@ -68,6 +87,35 @@ const checkQuota = (identifier) => {
 
   record.count += 1;
   return true;
+};
+
+const getQuotaKey = (identifier) => {
+  const windowBucket = Math.floor(Date.now() / QUOTA_WINDOW_MS);
+  return `quota:${identifier}:${windowBucket}`;
+};
+
+const checkQuota = async (identifier) => {
+  if (quotaRedis) {
+    try {
+      const key = getQuotaKey(identifier);
+      const results = await quotaRedis.multi().incr(key).pexpire(key, QUOTA_WINDOW_MS).exec();
+
+      const incrementResult = results?.[0]?.[1];
+      if (typeof incrementResult !== 'number') {
+        throw new Error('Unexpected quota increment response');
+      }
+
+      if (incrementResult > QUOTA_MAX_REQUESTS) {
+        return false;
+      }
+
+      return true;
+    } catch (err) {
+      logQuotaStoreFailure(err);
+    }
+  }
+
+  return checkQuotaFallback(identifier);
 };
 
 const systemPrompts = {
@@ -535,7 +583,7 @@ app.prepare().then(() => {
     }
 
     const requesterId = `${req.ip || 'unknown-ip'}::${req.headers['x-user-id'] || 'anonymous'}`;
-    if (!checkQuota(requesterId)) {
+    if (!(await checkQuota(requesterId))) {
       console.warn(`Quota exceeded for ${requesterId}`);
       return res.status(429).json({ error: 'Usage quota exceeded. Please try later.' });
     }

--- a/server.js
+++ b/server.js
@@ -119,9 +119,11 @@ const getQuotaScriptSha = async () => {
 
 const checkQuota = async (identifier) => {
   if (quotaRedis) {
+    const key = getQuotaKey(identifier);
+    let scriptSha;
+
     try {
-      const key = getQuotaKey(identifier);
-      const scriptSha = await getQuotaScriptSha();
+      scriptSha = await getQuotaScriptSha();
       const incrementResult = await quotaRedis.evalsha(scriptSha, 1, key, QUOTA_WINDOW_MS);
 
       if (incrementResult > QUOTA_MAX_REQUESTS) {
@@ -130,7 +132,23 @@ const checkQuota = async (identifier) => {
 
       return true;
     } catch (err) {
-      logQuotaStoreFailure(err);
+      if (err?.message?.includes('NOSCRIPT')) {
+        try {
+          quotaScriptSha = undefined;
+          scriptSha = await getQuotaScriptSha();
+          const incrementResult = await quotaRedis.evalsha(scriptSha, 1, key, QUOTA_WINDOW_MS);
+
+          if (incrementResult > QUOTA_MAX_REQUESTS) {
+            return false;
+          }
+
+          return true;
+        } catch (reloadErr) {
+          logQuotaStoreFailure(reloadErr);
+        }
+      } else {
+        logQuotaStoreFailure(err);
+      }
     }
   }
 

--- a/server.js
+++ b/server.js
@@ -89,21 +89,40 @@ const checkQuotaFallback = (identifier) => {
   return true;
 };
 
-const getQuotaKey = (identifier) => {
-  const windowBucket = Math.floor(Date.now() / QUOTA_WINDOW_MS);
-  return `quota:${identifier}:${windowBucket}`;
+const getQuotaKey = (identifier) => `quota:${identifier}`;
+
+const incrementQuotaScript = `
+local key = KEYS[1]
+local window_ms = tonumber(ARGV[1])
+
+local count = redis.call('INCR', key)
+if count == 1 then
+  redis.call('PEXPIRE', key, window_ms)
+else
+  local ttl = redis.call('PTTL', key)
+  if ttl < 0 then
+    redis.call('PEXPIRE', key, window_ms)
+  end
+end
+
+return count
+`;
+
+let quotaScriptSha;
+const getQuotaScriptSha = async () => {
+  if (!quotaScriptSha && quotaRedis) {
+    quotaScriptSha = await quotaRedis.script('LOAD', incrementQuotaScript);
+  }
+
+  return quotaScriptSha;
 };
 
 const checkQuota = async (identifier) => {
   if (quotaRedis) {
     try {
       const key = getQuotaKey(identifier);
-      const results = await quotaRedis.multi().incr(key).pexpire(key, QUOTA_WINDOW_MS).exec();
-
-      const incrementResult = results?.[0]?.[1];
-      if (typeof incrementResult !== 'number') {
-        throw new Error('Unexpected quota increment response');
-      }
+      const scriptSha = await getQuotaScriptSha();
+      const incrementResult = await quotaRedis.evalsha(scriptSha, 1, key, QUOTA_WINDOW_MS);
 
       if (incrementResult > QUOTA_MAX_REQUESTS) {
         return false;


### PR DESCRIPTION
## Summary
- add a Redis-backed shared quota store with atomic increments and window-based keys for rate enforcement
- fall back to an in-memory tracker with logging when the quota store is unavailable

## Testing
- TERM=dumb npm run build *(fails: export error for /_offline page; existing issue)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693eb597b968832ba51135ccefd260bb)