### PR TITLE
Add periodic cleanup for fallback quota tracking

### DIFF
--- a/server.js
+++ b/server.js
@@ -106,7 +106,34 @@ const quotaRedis = quotaRedisUrl
   ? new Redis(quotaRedisUrl, { enableOfflineQueue: false })
   : null;
 const fallbackQuotaTracker = new Map();
+let fallbackCleanupInterval;
 let quotaStoreFailureCount = 0;
+
+const cleanupFallbackQuotaTracker = () => {
+  const now = Date.now();
+  for (const [identifier, record] of fallbackQuotaTracker.entries()) {
+    if (!record?.expiresAt || record.expiresAt <= now) {
+      fallbackQuotaTracker.delete(identifier);
+    }
+  }
+};
+
+const startFallbackCleanup = () => {
+  if (fallbackCleanupInterval) {
+    return;
+  }
+
+  fallbackCleanupInterval = setInterval(cleanupFallbackQuotaTracker, Math.max(QUOTA_WINDOW_MS, 1_000));
+};
+
+const stopFallbackCleanup = () => {
+  if (!fallbackCleanupInterval) {
+    return;
+  }
+
+  clearInterval(fallbackCleanupInterval);
+  fallbackCleanupInterval = null;
+};
 
 const profanityList = ['damn', 'shit', 'fuck'];
 
@@ -143,12 +170,23 @@ if (quotaRedis) {
   quotaRedis.on('error', (err) => logQuotaStoreFailure(err));
 }
 
+['SIGINT', 'SIGTERM', 'exit'].forEach((event) => {
+  process.on(event, () => {
+    stopFallbackCleanup();
+  });
+});
+
 const checkQuotaFallback = (identifier) => {
+  startFallbackCleanup();
   const now = Date.now();
   const record = fallbackQuotaTracker.get(identifier);
 
-  if (!record || now - record.windowStart > QUOTA_WINDOW_MS) {
-    fallbackQuotaTracker.set(identifier, { windowStart: now, count: 1 });
+  if (!record || record.expiresAt <= now) {
+    fallbackQuotaTracker.set(identifier, {
+      windowStart: now,
+      count: 1,
+      expiresAt: now + QUOTA_WINDOW_MS,
+    });
     return { allowed: true, store: 'memory' };
   }
 

--- a/server.js
+++ b/server.js
@@ -170,10 +170,18 @@ if (quotaRedis) {
   quotaRedis.on('error', (err) => logQuotaStoreFailure(err));
 }
 
-['SIGINT', 'SIGTERM', 'exit'].forEach((event) => {
-  process.on(event, () => {
-    stopFallbackCleanup();
-  });
+const handleShutdownSignal = (signal) => {
+  stopFallbackCleanup();
+  process.removeListener(signal, handleShutdownSignal);
+  process.kill(process.pid, signal);
+};
+
+['SIGINT', 'SIGTERM'].forEach((event) => {
+  process.on(event, handleShutdownSignal);
+});
+
+process.on('exit', () => {
+  stopFallbackCleanup();
 });
 
 const checkQuotaFallback = (identifier) => {


### PR DESCRIPTION
## Summary
- add expiry timestamps to fallback quota records and periodically purge expired entries
- start cleanup when fallback quota tracking is used and stop interval during shutdown signals

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f25c6c044832b818678d882649718)